### PR TITLE
Remove name from call PersonInfo

### DIFF
--- a/src/main/kotlin/no/nav/syfo/controller/PersonController.kt
+++ b/src/main/kotlin/no/nav/syfo/controller/PersonController.kt
@@ -28,7 +28,6 @@ class PersonController @Inject constructor(
             val person = pdlConsumer.person(it)
             PersonInfo(
                     it.fnr,
-                    person?.getName() ?: "",
                     skjermingskodeService.hentBrukersSkjermingskode(person, it.fnr)
             )
         }

--- a/src/main/kotlin/no/nav/syfo/controller/domain/PersonInfo.kt
+++ b/src/main/kotlin/no/nav/syfo/controller/domain/PersonInfo.kt
@@ -1,7 +1,6 @@
 package no.nav.syfo.controller.domain
 
 data class PersonInfo(
-        val fnr: String = "",
         val navn: String,
         val skjermingskode: Skjermingskode
 )


### PR DESCRIPTION
Name is now supplied for all persons from PersonOversikt and hence is not needed from PersonInfo