### PR TITLE
Add new Gradering STRENGT_FORTROLIG_UTLAND in Adressebekyttelse

### DIFF
--- a/src/main/kotlin/no/nav/syfo/pdl/PdlPersonResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/pdl/PdlPersonResponse.kt
@@ -45,6 +45,7 @@ data class Adressebeskyttelse(
 ) : Serializable
 
 enum class Gradering : Serializable {
+    STRENGT_FORTROLIG_UTLAND,
     STRENGT_FORTROLIG,
     FORTROLIG,
     UGRADERT
@@ -52,16 +53,16 @@ enum class Gradering : Serializable {
 
 
 fun PdlHentPerson.getDiskresjonskode(): String {
-    val adressebeskyttelse = this.hentPerson?.adressebeskyttelse
-    if (adressebeskyttelse.isNullOrEmpty()) {
+    val adressebeskyttelseList = this.hentPerson?.adressebeskyttelse
+    if (adressebeskyttelseList.isNullOrEmpty()) {
         return ""
     } else {
-        val gradering: Gradering = adressebeskyttelse.first().gradering
+        val adressebeskyttelse = adressebeskyttelseList.first()
         return when {
-            gradering === Gradering.STRENGT_FORTROLIG -> {
+            adressebeskyttelse.isKode6() -> {
                 "6"
             }
-            gradering === Gradering.FORTROLIG -> {
+            adressebeskyttelse.isKode7() -> {
                 "7"
             }
             else -> {
@@ -77,9 +78,17 @@ fun PdlHentPerson.isKode6Or7(): Boolean {
         false
     } else {
         return adressebeskyttelse.any {
-            it.gradering == Gradering.STRENGT_FORTROLIG || it.gradering == Gradering.FORTROLIG
+            it.isKode6() || it.isKode7()
         }
     }
+}
+
+fun Adressebeskyttelse.isKode6(): Boolean {
+    return this.gradering == Gradering.STRENGT_FORTROLIG || this.gradering == Gradering.STRENGT_FORTROLIG_UTLAND
+}
+
+fun Adressebeskyttelse.isKode7(): Boolean {
+    return this.gradering == Gradering.FORTROLIG
 }
 
 fun PdlHentPerson.getName(): String? {

--- a/src/test/kotlin/no/nav/syfo/pdl/PdlResponseTest.kt
+++ b/src/test/kotlin/no/nav/syfo/pdl/PdlResponseTest.kt
@@ -56,6 +56,16 @@ class PdlResponseTest {
     }
 
     @Test
+    fun isKode6Or7WithGraderingStrengtFortroligUtland() {
+        val pdlPersonResponse = generatePdlHentPerson(
+                null,
+                Adressebeskyttelse(gradering = Gradering.STRENGT_FORTROLIG_UTLAND)
+        ).copy()
+        val result = pdlPersonResponse.isKode6Or7()
+        assertThat(result).isTrue()
+    }
+
+    @Test
     fun isNotKode6Or7WithGraderingUgradert() {
         val pdlPersonResponse = generatePdlHentPerson(
                 null,


### PR DESCRIPTION
STRENGT_FORTROLIG_UTLAND should be treatet the same as STRENGT_FORTROLIG, i.e. as a Kode6