### PR TITLE
Add endpoint to get KontaktInfo from DKIF

### DIFF
--- a/naiserator-dev.yaml
+++ b/naiserator-dev.yaml
@@ -57,6 +57,8 @@ spec:
       value: https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/.well-known/openid-configuration
     - name: NO_NAV_SECURITY_JWT_ISSUER_VEILEDER_ACCEPTEDAUDIENCE
       value: 38e07d31-659d-4595-939a-f18dce3446c5
+    - name: DKIF_URL
+      value: https://dkif.nais.preprod.local
     - name: PDL_URL
       value: https://pdl-api.nais.preprod.local/graphql
     - name: SECURITY_TOKEN_SERVICE_REST_URL

--- a/naiserator-prod.yaml
+++ b/naiserator-prod.yaml
@@ -57,6 +57,8 @@ spec:
       value: https://login.microsoftonline.com/navno.onmicrosoft.com/.well-known/openid-configuration
     - name: NO_NAV_SECURITY_JWT_ISSUER_VEILEDER_ACCEPTEDAUDIENCE
       value: 9b4e07a3-4f4c-4bab-b866-87f62dff480d
+    - name: DKIF_URL
+      value: https://dkif.nais.adeo.no
     - name: PDL_URL
       value: https://pdl-api.nais.adeo.no/graphql
     - name: SECURITY_TOKEN_SERVICE_REST_URL

--- a/src/main/kotlin/no/nav/syfo/consumer/dkif/DKIFRequestFailedException.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/dkif/DKIFRequestFailedException.kt
@@ -1,0 +1,11 @@
+package no.nav.syfo.consumer.dkif
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ResponseStatus
+
+const val dkifErrorMessage = "Request to get Kontakinformasjon from DKIF Failed"
+
+@ResponseStatus(code = HttpStatus.INTERNAL_SERVER_ERROR)
+class DKIFRequestFailedException(
+    message: String = ""
+) : RuntimeException("$dkifErrorMessage $message")

--- a/src/main/kotlin/no/nav/syfo/consumer/dkif/DigitalKontaktinfoBolk.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/dkif/DigitalKontaktinfoBolk.kt
@@ -1,0 +1,20 @@
+package no.nav.syfo.consumer.dkif
+
+import java.io.Serializable
+
+data class DigitalKontaktinfoBolk(
+    val feil: Map<String, Feil>? = null,
+    val kontaktinfo: Map<String, DigitalKontaktinfo>? = null
+) : Serializable
+
+data class DigitalKontaktinfo(
+    val epostadresse: String? = null,
+    val kanVarsles: Boolean,
+    val reservert: Boolean? = null,
+    val mobiltelefonnummer: String? = null,
+    val personident: String
+) : Serializable
+
+data class Feil(
+    val melding: String
+) : Serializable

--- a/src/main/kotlin/no/nav/syfo/consumer/dkif/DkifConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/dkif/DkifConsumer.kt
@@ -1,0 +1,71 @@
+package no.nav.syfo.consumer.dkif
+
+import no.nav.syfo.consumer.sts.StsConsumer
+import no.nav.syfo.metric.Metric
+import no.nav.syfo.person.api.domain.Fnr
+import no.nav.syfo.util.*
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.*
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestClientResponseException
+import org.springframework.web.client.RestTemplate
+
+@Service
+class DkifConsumer(
+    @Value("\${dkif.url}") private val dkifUrl: String,
+    private val metric: Metric,
+    private val stsConsumer: StsConsumer,
+    private val template: RestTemplate
+) {
+    private val dkifKontaktinfoUrl: String
+
+    init {
+        this.dkifKontaktinfoUrl = "$dkifUrl$DKIF_KONTAKTINFO_PATH"
+    }
+
+    fun digitalKontaktinfoBolk(ident: Fnr): DigitalKontaktinfoBolk {
+        try {
+            val response = template.exchange(
+                this.dkifKontaktinfoUrl,
+                HttpMethod.GET,
+                entity(ident),
+                DigitalKontaktinfoBolk::class.java
+            )
+
+            response.body?.let { digitalKontakinfoBolk ->
+                metric.countEvent(CALL_DKIF_SUCCESS)
+                return digitalKontakinfoBolk
+            } ?: run {
+                val errorMessage = "Failed to get Kontaktinfo from DKIF: ReponseBody is null"
+                LOG.error(errorMessage)
+                throw DKIFRequestFailedException(errorMessage)
+            }
+        } catch (e: RestClientResponseException) {
+            LOG.error("Request to get Kontaktinfo from DKIF failed with HTTP-status: ${e.rawStatusCode} and ${e.statusText}")
+            metric.countEvent(CALL_DKIF_FAIL)
+            throw e
+        }
+    }
+
+    private fun entity(ident: Fnr): HttpEntity<String> {
+        val token: String = stsConsumer.token()
+        val headers = HttpHeaders()
+        headers.contentType = MediaType.APPLICATION_JSON
+        headers[HttpHeaders.AUTHORIZATION] = bearerHeader(token)
+        headers[NAV_CONSUMER_ID_HEADER] = APP_CONSUMER_ID
+        headers[NAV_CALL_ID_HEADER] = createCallId()
+        headers[NAV_PERSONIDENTER_HEADER] = ident.fnr
+        return HttpEntity(headers)
+    }
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(DkifConsumer::class.java)
+
+        const val DKIF_KONTAKTINFO_PATH = "/api/v1/personer/kontaktinformasjon"
+
+        private const val CALL_DKIF_BASE = "call_dkif"
+        const val CALL_DKIF_FAIL = "${CALL_DKIF_BASE}_fail"
+        const val CALL_DKIF_SUCCESS = "${CALL_DKIF_BASE}_success"
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/util/HttpHeaderUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/HttpHeaderUtil.kt
@@ -6,6 +6,7 @@ const val NAV_CONSUMER_ID_HEADER = "Nav-Consumer-Id"
 const val APP_CONSUMER_ID = "syfoperson"
 
 const val NAV_PERSONIDENT_HEADER = "Nav-Personident"
+const val NAV_PERSONIDENTER_HEADER = "Nav-Personidenter"
 const val NAV_CALL_ID_HEADER = "Nav-Call-Id"
 const val TEMA_HEADER = "Tema"
 const val ALLE_TEMA_HEADERVERDI = "GEN"

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -23,6 +23,7 @@ srv.password: "password"
 
 fasit.environment.name: 'local'
 
+dkif.url: "https://dkif.nais.no"
 tilgangskontrollapi.url: "https://tilgangskontroll.nais.no"
 security.token.service.rest.url: "https://sts.nais.no"
 pdl.url: "https://pdl.nais.no"


### PR DESCRIPTION
This endpoint acts as a kind of proxy to get DigitalKontaktinfoBolk from DKIF, but with access control and som validation. This endpoint is supposed to be used by frontend i SYFO-apps in Modia en SYFO-apps i GCP that cannot access DKIF from GCP.