### PR TITLE
Bugfix invalid expire time

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/cache/RedisStore.kt
+++ b/src/main/kotlin/no/nav/syfo/application/cache/RedisStore.kt
@@ -37,14 +37,19 @@ class RedisStore(
         value: T,
     ) {
         val valueJson = objectMapper.writeValueAsString(value)
-        set(
-            expireSeconds = expireSeconds,
-            key = key,
-            value = valueJson,
-        )
+        if (expireSeconds > 0) {
+            set(
+                expireSeconds = expireSeconds,
+                key = key,
+                value = valueJson,
+            )
+        } else {
+            val message = "Won't put value into the Redis-cache with expireSeconds=$expireSeconds"
+            log.warn(message, Exception(message))
+        }
     }
 
-    fun set(
+    private fun set(
         expireSeconds: Long,
         key: String,
         value: String,


### PR DESCRIPTION
Fått en del forekomster av denne etter overgang til ktor: 

Failed to get response for resource=/oppfolgingstilfelle/arbeidsgiver, status=500 message=Failed to process request successfully, callId=null, message=ERR invalid expire time in setex callId=null

og 

Failed to get response for resource=/adresse, status=500 message=Failed to process request successfully, callId=null, message=ERR invalid expire time in setex callId=null