### PR TITLE
Catch ClosedReceiveChannelException to improve error handling

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/dkif/DkifClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/dkif/DkifClient.kt
@@ -3,6 +3,7 @@ package no.nav.syfo.client.dkif
 import io.ktor.client.features.*
 import io.ktor.client.request.*
 import io.ktor.http.*
+import kotlinx.coroutines.channels.ClosedReceiveChannelException
 import net.logstash.logback.argument.StructuredArguments
 import no.nav.syfo.client.azuread.AzureAdClient
 import no.nav.syfo.client.httpClientDefault
@@ -78,6 +79,9 @@ class DkifClient(
                 log.error(errorMessage)
                 throw DKIFRequestFailedException(errorMessage)
             }
+        } catch (e: ClosedReceiveChannelException) {
+            COUNT_CALL_DKIF_KONTAKTINFORMASJON_FAIL.increment()
+            throw RuntimeException("Caught ClosedReceiveChannelException in DkifClient.digitalKontaktinfoBolk", e)
         } catch (e: ResponseException) {
             log.error(
                 "Error while requesting Response from Ereg {}, {}, {}",

--- a/src/main/kotlin/no/nav/syfo/client/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/PdlClient.kt
@@ -5,6 +5,7 @@ import io.ktor.client.features.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
+import kotlinx.coroutines.channels.ClosedReceiveChannelException
 import net.logstash.logback.argument.StructuredArguments
 import no.nav.syfo.client.azuread.AzureAdClient
 import no.nav.syfo.client.httpClientDefault
@@ -132,6 +133,9 @@ class PdlClient(
                     return null
                 }
             }
+        } catch (e: ClosedReceiveChannelException) {
+            COUNT_CALL_PDL_PERSON_FAIL.increment()
+            throw RuntimeException("Caught ClosedReceiveChannelException in PdlClient.person", e)
         } catch (e: ResponseException) {
             COUNT_CALL_PDL_PERSON_FAIL.increment()
             log.error(

--- a/src/main/kotlin/no/nav/syfo/client/skjermedepersonerpip/SkjermedePersonerPipClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/skjermedepersonerpip/SkjermedePersonerPipClient.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.client.skjermedepersonerpip
 
 import io.ktor.client.features.*
 import io.ktor.client.request.*
+import kotlinx.coroutines.channels.ClosedReceiveChannelException
 import net.logstash.logback.argument.StructuredArguments
 import no.nav.syfo.application.cache.RedisStore
 import no.nav.syfo.client.azuread.AzureAdClient
@@ -49,6 +50,9 @@ class SkjermedePersonerPipClient(
                     value = skjermedePersonerResponse,
                 )
                 return skjermedePersonerResponse
+            } catch (e: ClosedReceiveChannelException) {
+                COUNT_CALL_SKJERMEDE_PERSONER__SKJERMET_FAIL.increment()
+                throw RuntimeException("Caught ClosedReceiveChannelException in SkjermedePersonerPipClient.isSkjermet", e)
             } catch (e: ResponseException) {
                 log.error(
                     "Error while requesting Response from Skjermede Person {}, {}, {}",


### PR DESCRIPTION
Ideen her er å få ut mer info om hvilke klientkall som er årsaken til ClosedReceiveChannelException. Har ikke lagt det inn over alt, men antar at det er ett eller flere av disse som nå har fått forbedret feilhåndtering som er årsaken til det vi ser i loggene.