### PR TITLE
Reduce cpu-allocation

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -22,15 +22,15 @@ spec:
     failureThreshold: 3
   resources:
     limits:
-      cpu: 1000m
+      cpu: 200m
       memory: 1024Mi
     requests:
-      cpu: 500m
-      memory: 768Mi
+      cpu: 100m
+      memory: 512Mi
   replicas:
     min: 2
     max: 4
-    cpuThresholdPercentage: 90
+    cpuThresholdPercentage: 70
   prometheus:
     enabled: true
     path: /internal/metrics

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -22,15 +22,15 @@ spec:
     failureThreshold: 3
   resources:
     limits:
-      cpu: 1000m
+      cpu: 200m
       memory: 1024Mi
     requests:
-      cpu: 500m
-      memory: 768Mi
+      cpu: 100m
+      memory: 512Mi
   replicas:
     min: 2
     max: 4
-    cpuThresholdPercentage: 90
+    cpuThresholdPercentage: 70
   prometheus:
     enabled: true
     path: /internal/metrics


### PR DESCRIPTION
syfoperson bruker mye mindre cpu enn det som er allokert, så reduserer i nais-filene slik at ikke dette bare blir sløsing. Reduserer i stedet terskelen for å spinne opp flere pod'er.