### PR TITLE
Add name to response object in API

### DIFF
--- a/src/main/kotlin/no/nav/syfo/person/api/PersonAPI.kt
+++ b/src/main/kotlin/no/nav/syfo/person/api/PersonAPI.kt
@@ -64,7 +64,8 @@ fun Route.registrerPersonApi(
                         )
                         PersonInfo(
                             fnr = personIdentNumber.value,
-                            skjermingskode = skjermingskode
+                            navn = person?.getFullName() ?: "",
+                            skjermingskode = skjermingskode,
                         )
                     }
                 call.respond(response)

--- a/src/main/kotlin/no/nav/syfo/person/api/domain/PersonInfo.kt
+++ b/src/main/kotlin/no/nav/syfo/person/api/domain/PersonInfo.kt
@@ -2,5 +2,6 @@ package no.nav.syfo.person.api.domain
 
 data class PersonInfo(
     val fnr: String,
+    val navn: String,
     val skjermingskode: Skjermingskode
 )

--- a/src/main/kotlin/no/nav/syfo/util/StringUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/StringUtil.kt
@@ -3,6 +3,16 @@ package no.nav.syfo.util
 import java.util.*
 
 fun String.lowerCapitalize() =
+    this.split(" ").joinToString(" ") { name ->
+        val nameWithDash = name.split("-")
+        if (nameWithDash.size > 1) {
+            nameWithDash.joinToString("-") { it.capitalizeName() }
+        } else {
+            name.capitalizeName()
+        }
+    }
+
+private fun String.capitalizeName() =
     this.lowercase(Locale.getDefault()).replaceFirstChar {
         if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
     }

--- a/src/test/kotlin/no/nav/syfo/person/api/PersonInfoApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/person/api/PersonInfoApiSpek.kt
@@ -68,6 +68,7 @@ class PersonInfoApiSpek : Spek({
                             personInfoList.size shouldBeEqualTo requestBody.size - 1
                             personInfoList[0].fnr shouldBeEqualTo ARBEIDSTAKER_PERSONIDENT.value
                             personInfoList[0].skjermingskode shouldBeEqualTo Skjermingskode.EGEN_ANSATT
+                            personInfoList[0].navn shouldBeEqualTo "${UserConstants.PERSON_NAME_FIRST} ${UserConstants.PERSON_NAME_MIDDLE} ${UserConstants.PERSON_NAME_LAST}"
                             personInfoList[1].fnr shouldBeEqualTo ARBEIDSTAKER_ALTERNATIVE_PERSONIDENT.value
                             personInfoList[1].skjermingskode shouldBeEqualTo Skjermingskode.INGEN
                             personInfoList[2].fnr shouldBeEqualTo ARBEIDSTAKER_ADRESSEBESKYTTET.value

--- a/src/test/kotlin/no/nav/syfo/util/StringUtilSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/util/StringUtilSpek.kt
@@ -1,0 +1,26 @@
+package no.nav.syfo.util
+
+import org.amshove.kluent.shouldBeEqualTo
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object StringUtilSpek : Spek({
+
+    describe("Test for String Utils") {
+
+        describe("Capitalize names") {
+            it("Should capitalize navn") {
+                "OLA".lowerCapitalize() shouldBeEqualTo "Ola"
+            }
+            it("Should capitalize navn with space") {
+                "JAN OLA".lowerCapitalize() shouldBeEqualTo "Jan Ola"
+            }
+            it("Should capitalize navn with dashes") {
+                "JAN-OLA".lowerCapitalize() shouldBeEqualTo "Jan-Ola"
+            }
+            it("Should capitalize navn with dashes and spaces") {
+                "JAN-OLA JON OLA-JAN JON JAN-O-JUL".lowerCapitalize() shouldBeEqualTo "Jan-Ola Jon Ola-Jan Jon Jan-O-Jul"
+            }
+        }
+    }
+})


### PR DESCRIPTION
Fant dette etter å ha jobbet en del med navn i det siste 😬 

Frontenden syfooversikt forventer allerede dette feltet, og bruker det også i koden som en backup dersom syfooversiktsrv ikke har navn. Ettersom vi uansett gjør kallet mot PDL og har navnet, så kan vi like godt sende det med.

Fikser også full-navn logikken på samme måte som i syfooversiktsrv.

Her er klassen som allerede finnes i frontenden syfooversikt:
![image](https://user-images.githubusercontent.com/37441744/207008540-46d6d67e-1241-43ae-bf62-960ca3d492bc.png)
