### PR TITLE
Added tilrettelagtKommunikasjon to PdlPerson and added test

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/PdlClient.kt
@@ -42,16 +42,16 @@ class PdlClient(
 
             when (response.status) {
                 HttpStatusCode.OK -> {
-                    val pdlReponse = response.body<PdlPersonResponse>()
-                    return if (!pdlReponse.errors.isNullOrEmpty()) {
+                    val pdlResponse = response.body<PdlPersonResponse>()
+                    return if (!pdlResponse.errors.isNullOrEmpty()) {
                         COUNT_CALL_PDL_PERSON_FAIL.increment()
-                        pdlReponse.errors.forEach {
+                        pdlResponse.errors.forEach {
                             log.error("Error while requesting person from PersonDataLosningen: ${it.errorMessage()}")
                         }
                         null
                     } else {
                         COUNT_CALL_PDL_PERSON_SUCCESS.increment()
-                        pdlReponse.data
+                        pdlResponse.data
                     }
                 }
                 else -> {

--- a/src/main/kotlin/no/nav/syfo/client/pdl/PdlPersonResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/PdlPersonResponse.kt
@@ -57,7 +57,7 @@ data class PdlPerson(
 data class PdlPersonNavn(
     val fornavn: String,
     val mellomnavn: String?,
-    val etternavn: String
+    val etternavn: String,
 ) : Serializable
 
 data class PdlDoedsfall(
@@ -66,20 +66,20 @@ data class PdlDoedsfall(
 
 data class PdlTilrettelagtKommunikasjon(
     val talespraaktolk: PdlSprak,
-    val tegnspraaktolk: PdlSprak
+    val tegnspraaktolk: PdlSprak,
 ) : Serializable
 
 data class PdlSprak(val spraak: String) : Serializable
 
 data class Adressebeskyttelse(
-    val gradering: Gradering
+    val gradering: Gradering,
 ) : Serializable
 
 enum class Gradering : Serializable {
     STRENGT_FORTROLIG_UTLAND,
     STRENGT_FORTROLIG,
     FORTROLIG,
-    UGRADERT
+    UGRADERT,
 }
 
 fun PdlHentPerson.getDiskresjonskode(): String {

--- a/src/main/kotlin/no/nav/syfo/client/pdl/PdlPersonResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/PdlPersonResponse.kt
@@ -35,7 +35,7 @@ data class PdlErrorExtension(
 data class PdlHentPerson(
     val hentPerson: PdlPerson?
 ) : Serializable {
-    fun getTilrettelagtKommunikasjon(): TilrettelagtKommunikasjon? =
+    val tilrettelagtKommunikasjon: TilrettelagtKommunikasjon? =
         hentPerson?.tilrettelagtKommunikasjon?.first()?.let {
             TilrettelagtKommunikasjon(
                 talesprakTolk = Sprak(it.talespraaktolk.spraak),

--- a/src/main/kotlin/no/nav/syfo/client/pdl/PdlPersonResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/PdlPersonResponse.kt
@@ -1,5 +1,7 @@
 package no.nav.syfo.client.pdl
 
+import no.nav.syfo.person.api.domain.syfomodiaperson.Sprak
+import no.nav.syfo.person.api.domain.syfomodiaperson.TilrettelagtKommunikasjon
 import no.nav.syfo.util.lowerCapitalize
 import java.io.Serializable
 import java.time.LocalDate
@@ -32,7 +34,15 @@ data class PdlErrorExtension(
 
 data class PdlHentPerson(
     val hentPerson: PdlPerson?
-) : Serializable
+) : Serializable {
+    fun getTilrettelagtKommunikasjon(): TilrettelagtKommunikasjon? =
+        hentPerson?.tilrettelagtKommunikasjon?.first()?.let {
+            TilrettelagtKommunikasjon(
+                talesprakTolk = Sprak(it.talespraaktolk.spraak),
+                tegnsprakTolk = Sprak(it.tegnspraaktolk.spraak),
+            )
+        }
+}
 
 data class PdlPerson(
     val navn: List<PdlPersonNavn>,
@@ -41,6 +51,7 @@ data class PdlPerson(
     val kontaktadresse: List<Kontaktadresse>?,
     val oppholdsadresse: List<Oppholdsadresse>?,
     val doedsfall: List<PdlDoedsfall>?,
+    val tilrettelagtKommunikasjon: List<PdlTilrettelagtKommunikasjon>?,
 ) : Serializable
 
 data class PdlPersonNavn(
@@ -52,6 +63,13 @@ data class PdlPersonNavn(
 data class PdlDoedsfall(
     val doedsdato: LocalDate?,
 ) : Serializable
+
+data class PdlTilrettelagtKommunikasjon(
+    val talespraaktolk: PdlSprak,
+    val tegnspraaktolk: PdlSprak
+) : Serializable
+
+data class PdlSprak(val spraak: String) : Serializable
 
 data class Adressebeskyttelse(
     val gradering: Gradering

--- a/src/main/kotlin/no/nav/syfo/client/pdl/PdlPersonResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/PdlPersonResponse.kt
@@ -36,7 +36,7 @@ data class PdlHentPerson(
     val hentPerson: PdlPerson?
 ) : Serializable {
     val tilrettelagtKommunikasjon: TilrettelagtKommunikasjon? =
-        hentPerson?.tilrettelagtKommunikasjon?.first()?.let {
+        hentPerson?.tilrettelagtKommunikasjon?.firstOrNull()?.let {
             TilrettelagtKommunikasjon(
                 talesprakTolk = Sprak(it.talespraaktolk.spraak),
                 tegnsprakTolk = Sprak(it.tegnspraaktolk.spraak),

--- a/src/main/kotlin/no/nav/syfo/client/pdl/PdlPersonResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/PdlPersonResponse.kt
@@ -51,7 +51,7 @@ data class PdlPerson(
     val kontaktadresse: List<Kontaktadresse>?,
     val oppholdsadresse: List<Oppholdsadresse>?,
     val doedsfall: List<PdlDoedsfall>?,
-    val tilrettelagtKommunikasjon: List<PdlTilrettelagtKommunikasjon>?,
+    val tilrettelagtKommunikasjon: List<PdlTilrettelagtKommunikasjon>,
 ) : Serializable
 
 data class PdlPersonNavn(
@@ -69,7 +69,7 @@ data class PdlTilrettelagtKommunikasjon(
     val tegnspraaktolk: PdlSprak?,
 ) : Serializable
 
-data class PdlSprak(val spraak: String) : Serializable
+data class PdlSprak(val spraak: String?) : Serializable
 
 data class Adressebeskyttelse(
     val gradering: Gradering,

--- a/src/main/kotlin/no/nav/syfo/client/pdl/PdlPersonResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/PdlPersonResponse.kt
@@ -38,8 +38,8 @@ data class PdlHentPerson(
     val tilrettelagtKommunikasjon: TilrettelagtKommunikasjon? =
         hentPerson?.tilrettelagtKommunikasjon?.firstOrNull()?.let {
             TilrettelagtKommunikasjon(
-                talesprakTolk = Sprak(it.talespraaktolk.spraak),
-                tegnsprakTolk = Sprak(it.tegnspraaktolk.spraak),
+                talesprakTolk = it.talespraaktolk?.spraak?.let { sprak -> Sprak(sprak) },
+                tegnsprakTolk = it.tegnspraaktolk?.spraak?.let { sprak -> Sprak(sprak) },
             )
         }
 }
@@ -65,8 +65,8 @@ data class PdlDoedsfall(
 ) : Serializable
 
 data class PdlTilrettelagtKommunikasjon(
-    val talespraaktolk: PdlSprak,
-    val tegnspraaktolk: PdlSprak,
+    val talespraaktolk: PdlSprak?,
+    val tegnspraaktolk: PdlSprak?,
 ) : Serializable
 
 data class PdlSprak(val spraak: String) : Serializable

--- a/src/main/kotlin/no/nav/syfo/person/api/PersonAPI.kt
+++ b/src/main/kotlin/no/nav/syfo/person/api/PersonAPI.kt
@@ -218,7 +218,7 @@ fun Route.registrerPersonApi(
                     navn = pdlPerson?.getFullName(),
                     kontaktinfo = kontaktinfo,
                     dodsdato = pdlPerson?.getDodsdato(),
-                    tilrettelagtKommunikasjon = pdlPerson?.getTilrettelagtKommunikasjon(),
+                    tilrettelagtKommunikasjon = pdlPerson?.tilrettelagtKommunikasjon,
                 )
                 call.respond(response)
             }

--- a/src/main/kotlin/no/nav/syfo/person/api/PersonAPI.kt
+++ b/src/main/kotlin/no/nav/syfo/person/api/PersonAPI.kt
@@ -218,6 +218,7 @@ fun Route.registrerPersonApi(
                     navn = pdlPerson?.getFullName(),
                     kontaktinfo = kontaktinfo,
                     dodsdato = pdlPerson?.getDodsdato(),
+                    tilrettelagtKommunikasjon = pdlPerson?.getTilrettelagtKommunikasjon(),
                 )
                 call.respond(response)
             }

--- a/src/main/kotlin/no/nav/syfo/person/api/domain/syfomodiaperson/SyfomodiapersonBrukerinfo.kt
+++ b/src/main/kotlin/no/nav/syfo/person/api/domain/syfomodiaperson/SyfomodiapersonBrukerinfo.kt
@@ -7,5 +7,5 @@ data class SyfomodiapersonBrukerinfo(
     val kontaktinfo: SyfomodiapersonKontaktinfo,
     val arbeidssituasjon: String = "ARBEIDSTAKER",
     val dodsdato: LocalDate? = null,
-    val tilrettelagtKommunikasjon: TilrettelagtKommunikasjon? = null
+    val tilrettelagtKommunikasjon: TilrettelagtKommunikasjon? = null,
 )

--- a/src/main/kotlin/no/nav/syfo/person/api/domain/syfomodiaperson/SyfomodiapersonBrukerinfo.kt
+++ b/src/main/kotlin/no/nav/syfo/person/api/domain/syfomodiaperson/SyfomodiapersonBrukerinfo.kt
@@ -7,4 +7,5 @@ data class SyfomodiapersonBrukerinfo(
     val kontaktinfo: SyfomodiapersonKontaktinfo,
     val arbeidssituasjon: String = "ARBEIDSTAKER",
     val dodsdato: LocalDate? = null,
+    val tilrettelagtKommunikasjon: TilrettelagtKommunikasjon? = null
 )

--- a/src/main/kotlin/no/nav/syfo/person/api/domain/syfomodiaperson/TilrettelagtKommunikasjon.kt
+++ b/src/main/kotlin/no/nav/syfo/person/api/domain/syfomodiaperson/TilrettelagtKommunikasjon.kt
@@ -1,8 +1,8 @@
 package no.nav.syfo.person.api.domain.syfomodiaperson
 
 data class TilrettelagtKommunikasjon(
-    val talesprakTolk: Sprak,
-    val tegnsprakTolk: Sprak
+    val talesprakTolk: Sprak?,
+    val tegnsprakTolk: Sprak?,
 )
 
 data class Sprak(val value: String)

--- a/src/main/kotlin/no/nav/syfo/person/api/domain/syfomodiaperson/TilrettelagtKommunikasjon.kt
+++ b/src/main/kotlin/no/nav/syfo/person/api/domain/syfomodiaperson/TilrettelagtKommunikasjon.kt
@@ -1,0 +1,8 @@
+package no.nav.syfo.person.api.domain.syfomodiaperson
+
+data class TilrettelagtKommunikasjon(
+    val talesprakTolk: Sprak,
+    val tegnsprakTolk: Sprak
+)
+
+data class Sprak(val value: String)

--- a/src/main/resources/pdl/hentPerson.graphql
+++ b/src/main/resources/pdl/hentPerson.graphql
@@ -17,6 +17,14 @@ query($ident: ID!, $navnHistorikk: Boolean!){
     doedsfall {
         doedsdato
     }
+    tilrettelagtKommunikasjon {
+        talespraaktolk {
+            spraak
+        }
+        tegnspraaktolk {
+            spraak
+        }
+    }
     bostedsadresse(historikk: false) {
       angittFlyttedato
       gyldigFraOgMed

--- a/src/test/kotlin/no/nav/syfo/person/api/PersonBrukerinfoApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/person/api/PersonBrukerinfoApiSpek.kt
@@ -99,7 +99,7 @@ class PersonBrukerinfoApiSpek : Spek({
                             val syfomodiapersonBrukerinfo: SyfomodiapersonBrukerinfo =
                                 objectMapper.readValue(response.content!!)
                             syfomodiapersonBrukerinfo.tilrettelagtKommunikasjon?.talesprakTolk?.value shouldBeEqualTo "Norsk (NO)"
-                            syfomodiapersonBrukerinfo.tilrettelagtKommunikasjon?.tegnsprakTolk?.value shouldBeEqualTo "Norsk (NO)"
+                            syfomodiapersonBrukerinfo.tilrettelagtKommunikasjon?.tegnsprakTolk?.value shouldBeEqualTo null
                         }
                     }
                 }

--- a/src/test/kotlin/no/nav/syfo/person/api/PersonBrukerinfoApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/person/api/PersonBrukerinfoApiSpek.kt
@@ -10,6 +10,7 @@ import no.nav.syfo.person.api.domain.syfomodiaperson.SyfomodiapersonBrukerinfo
 import no.nav.syfo.testhelper.*
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_DOD
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_PERSONIDENT
+import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_TILRETTELAGT_KOMMUNIKASJON
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_VEILEDER_NO_ACCESS
 import no.nav.syfo.testhelper.mock.digitalKontaktinfoBolkKanVarslesTrue
 import no.nav.syfo.util.*
@@ -70,6 +71,7 @@ class PersonBrukerinfoApiSpek : Spek({
                             syfomodiapersonBrukerinfo.kontaktinfo.skalHaVarsel shouldBeEqualTo true
                             syfomodiapersonBrukerinfo.navn shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.getFullName()
                             syfomodiapersonBrukerinfo.dodsdato shouldBe null
+                            syfomodiapersonBrukerinfo.tilrettelagtKommunikasjon shouldBe null
                         }
                     }
                     it("should include dodsdato") {
@@ -84,6 +86,19 @@ class PersonBrukerinfoApiSpek : Spek({
                                 objectMapper.readValue(response.content!!)
                             syfomodiapersonBrukerinfo.navn shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.getFullName()
                             syfomodiapersonBrukerinfo.dodsdato shouldBeEqualTo LocalDate.now()
+                        }
+                    }
+                    it("should include tilrettelagtKommunikasjon") {
+                        with(
+                            handleRequest(HttpMethod.Get, url) {
+                                addHeader(Authorization, bearerHeader(validToken))
+                                addHeader(NAV_PERSONIDENT_HEADER, ARBEIDSTAKER_TILRETTELAGT_KOMMUNIKASJON.value)
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.OK
+                            val syfomodiapersonBrukerinfo: SyfomodiapersonBrukerinfo =
+                                objectMapper.readValue(response.content!!)
+                            syfomodiapersonBrukerinfo.tilrettelagtKommunikasjon?.talesprakTolk?.value shouldBeEqualTo "Norsk (NO)"
                         }
                     }
                 }

--- a/src/test/kotlin/no/nav/syfo/person/api/PersonBrukerinfoApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/person/api/PersonBrukerinfoApiSpek.kt
@@ -99,6 +99,7 @@ class PersonBrukerinfoApiSpek : Spek({
                             val syfomodiapersonBrukerinfo: SyfomodiapersonBrukerinfo =
                                 objectMapper.readValue(response.content!!)
                             syfomodiapersonBrukerinfo.tilrettelagtKommunikasjon?.talesprakTolk?.value shouldBeEqualTo "Norsk (NO)"
+                            syfomodiapersonBrukerinfo.tilrettelagtKommunikasjon?.tegnsprakTolk?.value shouldBeEqualTo "Norsk (NO)"
                         }
                     }
                 }

--- a/src/test/kotlin/no/nav/syfo/testhelper/PdlPersonResponseGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/PdlPersonResponseGenerator.kt
@@ -81,6 +81,7 @@ fun generatePdlHentPerson(
             doedsfall = if (doedsdato == null) emptyList() else {
                 listOf(PdlDoedsfall(doedsdato))
             },
+            tilrettelagtKommunikasjon = emptyList(),
         )
     )
 }

--- a/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
@@ -10,6 +10,7 @@ object UserConstants {
     val ARBEIDSTAKER_VEILEDER_NO_ACCESS = PersonIdentNumber(ARBEIDSTAKER_PERSONIDENT.value.replace("2", "1"))
     val ARBEIDSTAKER_ADRESSEBESKYTTET = PersonIdentNumber(ARBEIDSTAKER_PERSONIDENT.value.replace("2", "6"))
     val ARBEIDSTAKER_DOD = PersonIdentNumber(ARBEIDSTAKER_PERSONIDENT.value.replace("2", "7"))
+    val ARBEIDSTAKER_TILRETTELAGT_KOMMUNIKASJON = PersonIdentNumber(ARBEIDSTAKER_PERSONIDENT.value.replace("2", "8"))
 
     const val PERSON_TLF = "12345678"
     const val PERSON_EMAIL = "test@nav.no"

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/PdlMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/PdlMock.kt
@@ -11,18 +11,21 @@ import no.nav.syfo.client.pdl.*
 import no.nav.syfo.testhelper.UserConstants
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_ADRESSEBESKYTTET
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_DOD
+import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_TILRETTELAGT_KOMMUNIKASJON
 import no.nav.syfo.testhelper.getRandomPort
 import java.time.LocalDate
 
 fun generatePdlPersonResponse(
     gradering: Gradering? = null,
     doedsdato: LocalDate? = null,
+    tilrettelagtKommunikasjon: PdlTilrettelagtKommunikasjon? = null,
 ) = PdlPersonResponse(
     errors = null,
     data = generatePdlHentPerson(
         pdlPersonNavn = generatePdlPersonNavn(),
         adressebeskyttelse = generateAdressebeskyttelse(gradering = gradering),
         doedsdato = doedsdato,
+        tilrettelagtKommunikasjon = tilrettelagtKommunikasjon,
     )
 )
 
@@ -46,6 +49,7 @@ fun generatePdlHentPerson(
     pdlPersonNavn: PdlPersonNavn?,
     adressebeskyttelse: Adressebeskyttelse? = null,
     doedsdato: LocalDate? = null,
+    tilrettelagtKommunikasjon: PdlTilrettelagtKommunikasjon? = null,
 ): PdlHentPerson {
     return PdlHentPerson(
         hentPerson = PdlPerson(
@@ -61,9 +65,16 @@ fun generatePdlHentPerson(
             doedsfall = if (doedsdato == null) emptyList() else {
                 listOf(PdlDoedsfall(doedsdato))
             },
+            tilrettelagtKommunikasjon = tilrettelagtKommunikasjon?.let { listOf(it) }
         )
     )
 }
+
+private fun generatePdlTilrettelagtKommunikasjon(): PdlTilrettelagtKommunikasjon =
+    PdlTilrettelagtKommunikasjon(
+        talespraaktolk = PdlSprak(spraak = "Norsk (NO)"),
+        tegnspraaktolk = PdlSprak(spraak = "Norsk (NO)")
+    )
 
 class PdlMock {
     private val port = getRandomPort()
@@ -84,6 +95,8 @@ class PdlMock {
                         generatePdlPersonResponse(Gradering.STRENGT_FORTROLIG)
                     } else if (ARBEIDSTAKER_DOD.value == pdlRequest.variables.ident) {
                         generatePdlPersonResponse(doedsdato = LocalDate.now())
+                    } else if (ARBEIDSTAKER_TILRETTELAGT_KOMMUNIKASJON.value == pdlRequest.variables.ident) {
+                        generatePdlPersonResponse(tilrettelagtKommunikasjon = generatePdlTilrettelagtKommunikasjon())
                     } else {
                         personResponseDefault
                     }

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/PdlMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/PdlMock.kt
@@ -65,7 +65,7 @@ fun generatePdlHentPerson(
             doedsfall = if (doedsdato == null) emptyList() else {
                 listOf(PdlDoedsfall(doedsdato))
             },
-            tilrettelagtKommunikasjon = tilrettelagtKommunikasjon?.let { listOf(it) }
+            tilrettelagtKommunikasjon = listOfNotNull(tilrettelagtKommunikasjon)
         )
     )
 }
@@ -73,7 +73,7 @@ fun generatePdlHentPerson(
 private fun generatePdlTilrettelagtKommunikasjon(): PdlTilrettelagtKommunikasjon =
     PdlTilrettelagtKommunikasjon(
         talespraaktolk = PdlSprak(spraak = "Norsk (NO)"),
-        tegnspraaktolk = PdlSprak(spraak = "Norsk (NO)")
+        tegnspraaktolk = PdlSprak(spraak = null),
     )
 
 class PdlMock {


### PR DESCRIPTION
Det har dukket opp et behov for å vise om personen trenger tilrettelagt kommunikasjon. Særlig om personen trenger tolk i forbindelse med dialogmøter.

La til at vi eksponerer `tilrettelagtKommunikasjon` i `/brukerinfo` endepunktet.
Dette omfatter språk for talespråk og tegnspråk. Vi vil vise denne informasjonen i `syfomodiaperson` appen.