### PR TITLE
Enforces nullability and changes spraak to realistic response

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/pdl/PdlPersonResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/PdlPersonResponse.kt
@@ -33,10 +33,10 @@ data class PdlErrorExtension(
 )
 
 data class PdlHentPerson(
-    val hentPerson: PdlPerson?
+    val hentPerson: PdlPerson
 ) : Serializable {
     val tilrettelagtKommunikasjon: TilrettelagtKommunikasjon? =
-        hentPerson?.tilrettelagtKommunikasjon?.firstOrNull()?.let {
+        hentPerson.tilrettelagtKommunikasjon.firstOrNull()?.let {
             TilrettelagtKommunikasjon(
                 talesprakTolk = it.talespraaktolk?.spraak?.let { sprak -> Sprak(sprak) },
                 tegnsprakTolk = it.tegnspraaktolk?.spraak?.let { sprak -> Sprak(sprak) },
@@ -83,7 +83,7 @@ enum class Gradering : Serializable {
 }
 
 fun PdlHentPerson.getDiskresjonskode(): String {
-    val adressebeskyttelseList = this.hentPerson?.adressebeskyttelse
+    val adressebeskyttelseList = this.hentPerson.adressebeskyttelse
     if (adressebeskyttelseList.isNullOrEmpty()) {
         return ""
     } else {
@@ -92,9 +92,11 @@ fun PdlHentPerson.getDiskresjonskode(): String {
             adressebeskyttelse.isKode6() -> {
                 "6"
             }
+
             adressebeskyttelse.isKode7() -> {
                 "7"
             }
+
             else -> {
                 ""
             }
@@ -103,7 +105,7 @@ fun PdlHentPerson.getDiskresjonskode(): String {
 }
 
 fun PdlHentPerson.isKode6Or7(): Boolean {
-    val adressebeskyttelse = this.hentPerson?.adressebeskyttelse
+    val adressebeskyttelse = this.hentPerson.adressebeskyttelse
     return if (adressebeskyttelse.isNullOrEmpty()) {
         false
     } else {
@@ -122,11 +124,11 @@ fun Adressebeskyttelse.isKode7(): Boolean {
 }
 
 fun PdlHentPerson.getFullName(): String? {
-    val nameList = this.hentPerson?.navn
-    if (nameList.isNullOrEmpty()) {
+    val names = this.hentPerson.navn
+    if (names.isEmpty()) {
         return null
     }
-    nameList[0].let {
+    names[0].let {
         val firstName = it.fornavn.lowerCapitalize()
         val middleName = it.mellomnavn
         val surName = it.etternavn.lowerCapitalize()
@@ -139,10 +141,10 @@ fun PdlHentPerson.getFullName(): String? {
     }
 }
 
-fun PdlHentPerson.getDodsdato() = hentPerson?.doedsfall?.firstOrNull()?.doedsdato
+fun PdlHentPerson.getDodsdato() = hentPerson.doedsfall?.firstOrNull()?.doedsdato
 
 fun PdlHentPerson.bostedsadresse(): Bostedsadresse? {
-    val bostedsadresse = this.hentPerson?.bostedsadresse
+    val bostedsadresse = this.hentPerson.bostedsadresse
     if (bostedsadresse.isNullOrEmpty()) {
         return null
     }
@@ -152,7 +154,7 @@ fun PdlHentPerson.bostedsadresse(): Bostedsadresse? {
 }
 
 fun PdlHentPerson.kontaktadresse(): Kontaktadresse? {
-    val kontaktadresse = this.hentPerson?.kontaktadresse
+    val kontaktadresse = this.hentPerson.kontaktadresse
     if (kontaktadresse.isNullOrEmpty()) {
         return null
     }
@@ -162,7 +164,7 @@ fun PdlHentPerson.kontaktadresse(): Kontaktadresse? {
 }
 
 fun PdlHentPerson.oppholdsadresse(): Oppholdsadresse? {
-    val oppholdsadresse = this.hentPerson?.oppholdsadresse
+    val oppholdsadresse = this.hentPerson.oppholdsadresse
     if (oppholdsadresse.isNullOrEmpty()) {
         return null
     }

--- a/src/main/kotlin/no/nav/syfo/client/pdl/PdlPersonResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/PdlPersonResponse.kt
@@ -73,10 +73,10 @@ data class PdlPerson(
             }
         } ?: ""
 
-    fun getBostedsadresse(): Bostedsadresse? =
+    fun hentBostedsadresse(): Bostedsadresse? =
         bostedsadresse?.filter { it.gyldigFraOgMed != null }?.maxByOrNull { it.gyldigFraOgMed!! }
 
-    val getTilrettelagtKommunikasjon: TilrettelagtKommunikasjon? =
+    fun hentTilrettelagtKommunikasjon(): TilrettelagtKommunikasjon? =
         tilrettelagtKommunikasjon.firstOrNull()?.let {
             TilrettelagtKommunikasjon(
                 talesprakTolk = it.talespraaktolk?.spraak?.let { sprak -> Sprak(sprak) },
@@ -86,10 +86,10 @@ data class PdlPerson(
 
     val dodsdato: LocalDate? = doedsfall?.firstOrNull()?.doedsdato
 
-    fun getKontaktadresse(): Kontaktadresse? =
+    fun hentKontaktadresse(): Kontaktadresse? =
         kontaktadresse?.filter { it.gyldigFraOgMed != null }?.maxByOrNull { it.gyldigFraOgMed!! }
 
-    fun getOppholdsadresse(): Oppholdsadresse? =
+    fun hentOppholdsadresse(): Oppholdsadresse? =
         oppholdsadresse?.filter { it.gyldigFraOgMed != null }?.maxByOrNull { it.gyldigFraOgMed!! }
 }
 

--- a/src/main/kotlin/no/nav/syfo/client/pdl/PdlPersonResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/PdlPersonResponse.kt
@@ -33,16 +33,8 @@ data class PdlErrorExtension(
 )
 
 data class PdlHentPerson(
-    val hentPerson: PdlPerson
-) : Serializable {
-    val tilrettelagtKommunikasjon: TilrettelagtKommunikasjon? =
-        hentPerson.tilrettelagtKommunikasjon.firstOrNull()?.let {
-            TilrettelagtKommunikasjon(
-                talesprakTolk = it.talespraaktolk?.spraak?.let { sprak -> Sprak(sprak) },
-                tegnsprakTolk = it.tegnspraaktolk?.spraak?.let { sprak -> Sprak(sprak) },
-            )
-        }
-}
+    val hentPerson: PdlPerson?
+) : Serializable
 
 data class PdlPerson(
     val navn: List<PdlPersonNavn>,
@@ -52,7 +44,54 @@ data class PdlPerson(
     val oppholdsadresse: List<Oppholdsadresse>?,
     val doedsfall: List<PdlDoedsfall>?,
     val tilrettelagtKommunikasjon: List<PdlTilrettelagtKommunikasjon>,
-) : Serializable
+) : Serializable {
+
+    val fullName: String? =
+        navn.firstOrNull()?.let {
+            val firstName = it.fornavn.lowerCapitalize()
+            val middleName = it.mellomnavn
+            val surName = it.etternavn.lowerCapitalize()
+
+            if (middleName.isNullOrBlank()) {
+                "$firstName $surName"
+            } else {
+                "$firstName ${middleName.lowerCapitalize()} $surName"
+            }
+        }
+
+    val isKode6Or7: Boolean =
+        adressebeskyttelse?.any {
+            it.isKode6() || it.isKode7()
+        } ?: false
+
+    val diskresjonskode: String =
+        adressebeskyttelse?.firstOrNull()?.let {
+            when {
+                it.isKode6() -> "6"
+                it.isKode7() -> "7"
+                else -> ""
+            }
+        } ?: ""
+
+    val getBostedsadresse: Bostedsadresse? =
+        bostedsadresse?.filter { it.gyldigFraOgMed != null }?.maxByOrNull { it.gyldigFraOgMed!! }
+
+    val getTilrettelagtKommunikasjon: TilrettelagtKommunikasjon? =
+        tilrettelagtKommunikasjon.firstOrNull()?.let {
+            TilrettelagtKommunikasjon(
+                talesprakTolk = it.talespraaktolk?.spraak?.let { sprak -> Sprak(sprak) },
+                tegnsprakTolk = it.tegnspraaktolk?.spraak?.let { sprak -> Sprak(sprak) },
+            )
+        }
+
+    val dodsdato: LocalDate? = doedsfall?.firstOrNull()?.doedsdato
+
+    val getKontaktadresse: Kontaktadresse? =
+        kontaktadresse?.filter { it.gyldigFraOgMed != null }?.maxByOrNull { it.gyldigFraOgMed!! }
+
+    val getOppholdsadresse: Oppholdsadresse? =
+        oppholdsadresse?.filter { it.gyldigFraOgMed != null }?.maxByOrNull { it.gyldigFraOgMed!! }
+}
 
 data class PdlPersonNavn(
     val fornavn: String,
@@ -73,102 +112,18 @@ data class PdlSprak(val spraak: String?) : Serializable
 
 data class Adressebeskyttelse(
     val gradering: Gradering,
-) : Serializable
+) : Serializable {
+
+    fun isKode6(): Boolean =
+        gradering == Gradering.STRENGT_FORTROLIG || gradering == Gradering.STRENGT_FORTROLIG_UTLAND
+
+    fun isKode7(): Boolean =
+        gradering == Gradering.FORTROLIG
+}
 
 enum class Gradering : Serializable {
     STRENGT_FORTROLIG_UTLAND,
     STRENGT_FORTROLIG,
     FORTROLIG,
     UGRADERT,
-}
-
-fun PdlHentPerson.getDiskresjonskode(): String {
-    val adressebeskyttelseList = this.hentPerson.adressebeskyttelse
-    if (adressebeskyttelseList.isNullOrEmpty()) {
-        return ""
-    } else {
-        val adressebeskyttelse = adressebeskyttelseList.first()
-        return when {
-            adressebeskyttelse.isKode6() -> {
-                "6"
-            }
-
-            adressebeskyttelse.isKode7() -> {
-                "7"
-            }
-
-            else -> {
-                ""
-            }
-        }
-    }
-}
-
-fun PdlHentPerson.isKode6Or7(): Boolean {
-    val adressebeskyttelse = this.hentPerson.adressebeskyttelse
-    return if (adressebeskyttelse.isNullOrEmpty()) {
-        false
-    } else {
-        return adressebeskyttelse.any {
-            it.isKode6() || it.isKode7()
-        }
-    }
-}
-
-fun Adressebeskyttelse.isKode6(): Boolean {
-    return this.gradering == Gradering.STRENGT_FORTROLIG || this.gradering == Gradering.STRENGT_FORTROLIG_UTLAND
-}
-
-fun Adressebeskyttelse.isKode7(): Boolean {
-    return this.gradering == Gradering.FORTROLIG
-}
-
-fun PdlHentPerson.getFullName(): String? {
-    val names = this.hentPerson.navn
-    if (names.isEmpty()) {
-        return null
-    }
-    names[0].let {
-        val firstName = it.fornavn.lowerCapitalize()
-        val middleName = it.mellomnavn
-        val surName = it.etternavn.lowerCapitalize()
-
-        return if (middleName.isNullOrBlank()) {
-            "$firstName $surName"
-        } else {
-            "$firstName ${middleName.lowerCapitalize()} $surName"
-        }
-    }
-}
-
-fun PdlHentPerson.getDodsdato() = hentPerson.doedsfall?.firstOrNull()?.doedsdato
-
-fun PdlHentPerson.bostedsadresse(): Bostedsadresse? {
-    val bostedsadresse = this.hentPerson.bostedsadresse
-    if (bostedsadresse.isNullOrEmpty()) {
-        return null
-    }
-    return bostedsadresse.filter {
-        it.gyldigFraOgMed != null
-    }.maxByOrNull { it.gyldigFraOgMed!! }
-}
-
-fun PdlHentPerson.kontaktadresse(): Kontaktadresse? {
-    val kontaktadresse = this.hentPerson.kontaktadresse
-    if (kontaktadresse.isNullOrEmpty()) {
-        return null
-    }
-    return kontaktadresse.filter {
-        it.gyldigFraOgMed != null
-    }.maxByOrNull { it.gyldigFraOgMed!! }
-}
-
-fun PdlHentPerson.oppholdsadresse(): Oppholdsadresse? {
-    val oppholdsadresse = this.hentPerson.oppholdsadresse
-    if (oppholdsadresse.isNullOrEmpty()) {
-        return null
-    }
-    return oppholdsadresse.filter {
-        it.gyldigFraOgMed != null
-    }.maxByOrNull { it.gyldigFraOgMed!! }
 }

--- a/src/main/kotlin/no/nav/syfo/client/pdl/PdlPersonResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/PdlPersonResponse.kt
@@ -73,7 +73,7 @@ data class PdlPerson(
             }
         } ?: ""
 
-    val getBostedsadresse: Bostedsadresse? =
+    fun getBostedsadresse(): Bostedsadresse? =
         bostedsadresse?.filter { it.gyldigFraOgMed != null }?.maxByOrNull { it.gyldigFraOgMed!! }
 
     val getTilrettelagtKommunikasjon: TilrettelagtKommunikasjon? =
@@ -86,10 +86,10 @@ data class PdlPerson(
 
     val dodsdato: LocalDate? = doedsfall?.firstOrNull()?.doedsdato
 
-    val getKontaktadresse: Kontaktadresse? =
+    fun getKontaktadresse(): Kontaktadresse? =
         kontaktadresse?.filter { it.gyldigFraOgMed != null }?.maxByOrNull { it.gyldigFraOgMed!! }
 
-    val getOppholdsadresse: Oppholdsadresse? =
+    fun getOppholdsadresse(): Oppholdsadresse? =
         oppholdsadresse?.filter { it.gyldigFraOgMed != null }?.maxByOrNull { it.gyldigFraOgMed!! }
 }
 

--- a/src/main/kotlin/no/nav/syfo/person/api/PersonAPI.kt
+++ b/src/main/kotlin/no/nav/syfo/person/api/PersonAPI.kt
@@ -164,9 +164,9 @@ fun Route.registrerPersonApi(
                 pdlPerson?.hentPerson?.let { person ->
                     val response = PersonAdresseResponse(
                         navn = person.fullName ?: "",
-                        bostedsadresse = person.getBostedsadresse,
-                        kontaktadresse = person.getKontaktadresse,
-                        oppholdsadresse = person.getOppholdsadresse
+                        bostedsadresse = person.getBostedsadresse(),
+                        kontaktadresse = person.getKontaktadresse(),
+                        oppholdsadresse = person.getOppholdsadresse(),
                     )
                     call.respond(response)
                 } ?: call.respond(HttpStatusCode.InternalServerError)

--- a/src/main/kotlin/no/nav/syfo/person/api/PersonAPI.kt
+++ b/src/main/kotlin/no/nav/syfo/person/api/PersonAPI.kt
@@ -169,7 +169,7 @@ fun Route.registrerPersonApi(
                         oppholdsadresse = person.getOppholdsadresse
                     )
                     call.respond(response)
-                } ?: call.respond(HttpStatusCode.NotFound)
+                } ?: call.respond(HttpStatusCode.InternalServerError)
             }
         }
 
@@ -227,7 +227,7 @@ fun Route.registrerPersonApi(
                         tilrettelagtKommunikasjon = person.getTilrettelagtKommunikasjon,
                     )
                     call.respond(response)
-                } ?: call.respond(HttpStatusCode.NotFound)
+                } ?: call.respond(HttpStatusCode.InternalServerError)
             }
         }
     }

--- a/src/main/kotlin/no/nav/syfo/person/api/PersonAPI.kt
+++ b/src/main/kotlin/no/nav/syfo/person/api/PersonAPI.kt
@@ -164,9 +164,9 @@ fun Route.registrerPersonApi(
                 pdlPerson?.hentPerson?.let { person ->
                     val response = PersonAdresseResponse(
                         navn = person.fullName ?: "",
-                        bostedsadresse = person.getBostedsadresse(),
-                        kontaktadresse = person.getKontaktadresse(),
-                        oppholdsadresse = person.getOppholdsadresse(),
+                        bostedsadresse = person.hentBostedsadresse(),
+                        kontaktadresse = person.hentKontaktadresse(),
+                        oppholdsadresse = person.hentOppholdsadresse(),
                     )
                     call.respond(response)
                 } ?: call.respond(HttpStatusCode.InternalServerError)
@@ -224,7 +224,7 @@ fun Route.registrerPersonApi(
                         navn = person.fullName,
                         kontaktinfo = kontaktinfo,
                         dodsdato = person.dodsdato,
-                        tilrettelagtKommunikasjon = person.getTilrettelagtKommunikasjon,
+                        tilrettelagtKommunikasjon = person.hentTilrettelagtKommunikasjon(),
                     )
                     call.respond(response)
                 } ?: call.respond(HttpStatusCode.InternalServerError)

--- a/src/main/kotlin/no/nav/syfo/person/skjermingskode/SkjermingskodeService.kt
+++ b/src/main/kotlin/no/nav/syfo/person/skjermingskode/SkjermingskodeService.kt
@@ -11,11 +11,11 @@ class SkjermingskodeService(
 ) {
     suspend fun hentBrukersSkjermingskode(
         callId: String,
-        person: PdlHentPerson?,
+        person: PdlHentPerson,
         personIdent: PersonIdentNumber,
         token: String,
     ): Skjermingskode {
-        if (person?.isKode6Or7() == true)
+        if (person.isKode6Or7())
             return Skjermingskode.DISKRESJONSMERKET
         return if (
             skjermedePersonerPipClient.isSkjermet(

--- a/src/main/kotlin/no/nav/syfo/person/skjermingskode/SkjermingskodeService.kt
+++ b/src/main/kotlin/no/nav/syfo/person/skjermingskode/SkjermingskodeService.kt
@@ -1,7 +1,6 @@
 package no.nav.syfo.person.skjermingskode
 
-import no.nav.syfo.client.pdl.PdlHentPerson
-import no.nav.syfo.client.pdl.isKode6Or7
+import no.nav.syfo.client.pdl.PdlPerson
 import no.nav.syfo.client.skjermedepersonerpip.SkjermedePersonerPipClient
 import no.nav.syfo.domain.PersonIdentNumber
 import no.nav.syfo.person.api.domain.Skjermingskode
@@ -11,11 +10,11 @@ class SkjermingskodeService(
 ) {
     suspend fun hentBrukersSkjermingskode(
         callId: String,
-        person: PdlHentPerson,
+        person: PdlPerson,
         personIdent: PersonIdentNumber,
         token: String,
     ): Skjermingskode {
-        if (person.isKode6Or7())
+        if (person.isKode6Or7)
             return Skjermingskode.DISKRESJONSMERKET
         return if (
             skjermedePersonerPipClient.isSkjermet(

--- a/src/test/kotlin/no/nav/syfo/consumer/pdl/PdlPersonResponseSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/consumer/pdl/PdlPersonResponseSpek.kt
@@ -13,7 +13,7 @@ import java.time.LocalDate
 class PdlPersonResponseSpek : Spek({
     describe(PersonNavnApiSpek::class.java.simpleName) {
 
-        it("getFullName") {
+        it("fullName") {
             val pdlPersonResponse = generatePdlHentPerson(
                 PdlPersonNavn(
                     UserConstants.PERSON_NAME_FIRST,
@@ -22,13 +22,13 @@ class PdlPersonResponseSpek : Spek({
                 ),
                 null,
             )
-            val result = pdlPersonResponse.getFullName()
+            val result = pdlPersonResponse.hentPerson?.fullName
             val expected =
                 "${UserConstants.PERSON_NAME_FIRST} ${UserConstants.PERSON_NAME_MIDDLE} ${UserConstants.PERSON_NAME_LAST}"
             result shouldBeEqualTo expected
         }
 
-        it("getFullName with no middle name") {
+        it("fullName with no middle name") {
             val pdlPersonResponse = generatePdlHentPerson(
                 PdlPersonNavn(
                     UserConstants.PERSON_NAME_FIRST,
@@ -37,7 +37,7 @@ class PdlPersonResponseSpek : Spek({
                 ),
                 null,
             )
-            val result = pdlPersonResponse.getFullName()
+            val result = pdlPersonResponse.hentPerson?.fullName
             val expected = "${UserConstants.PERSON_NAME_FIRST} ${UserConstants.PERSON_NAME_LAST}"
             result shouldBeEqualTo expected
         }
@@ -52,7 +52,7 @@ class PdlPersonResponseSpek : Spek({
                 null,
                 doedsdato = LocalDate.now(),
             )
-            val result = pdlPersonResponse.getDodsdato()
+            val result = pdlPersonResponse.hentPerson?.dodsdato
             result shouldBeEqualTo LocalDate.now()
         }
 
@@ -66,7 +66,7 @@ class PdlPersonResponseSpek : Spek({
                 null,
                 doedsdato = null,
             )
-            val result = pdlPersonResponse.getDodsdato()
+            val result = pdlPersonResponse.hentPerson?.dodsdato
             result shouldBe null
         }
 
@@ -75,7 +75,7 @@ class PdlPersonResponseSpek : Spek({
                 null,
                 Adressebeskyttelse(gradering = Gradering.FORTROLIG),
             ).copy()
-            val result = pdlPersonResponse.isKode6Or7()
+            val result = pdlPersonResponse.hentPerson?.isKode6Or7
             val expected = true
             result shouldBeEqualTo expected
         }
@@ -85,7 +85,7 @@ class PdlPersonResponseSpek : Spek({
                 null,
                 Adressebeskyttelse(gradering = Gradering.STRENGT_FORTROLIG),
             ).copy()
-            val result = pdlPersonResponse.isKode6Or7()
+            val result = pdlPersonResponse.hentPerson?.isKode6Or7
             val expected = true
             result shouldBeEqualTo expected
         }
@@ -95,7 +95,7 @@ class PdlPersonResponseSpek : Spek({
                 null,
                 Adressebeskyttelse(gradering = Gradering.STRENGT_FORTROLIG_UTLAND),
             )
-            val result = pdlPersonResponse.isKode6Or7()
+            val result = pdlPersonResponse.hentPerson?.isKode6Or7
             val expected = true
             result shouldBeEqualTo expected
         }
@@ -105,7 +105,7 @@ class PdlPersonResponseSpek : Spek({
                 null,
                 Adressebeskyttelse(gradering = Gradering.UGRADERT),
             )
-            val result = pdlPersonResponse.isKode6Or7()
+            val result = pdlPersonResponse.hentPerson?.isKode6Or7
             val expected = false
             result shouldBeEqualTo expected
         }

--- a/src/test/kotlin/no/nav/syfo/person/api/PersonAdresseApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/person/api/PersonAdresseApiSpek.kt
@@ -90,6 +90,16 @@ class PersonAdresseApiSpek : Spek({
                             response.status() shouldBeEqualTo HttpStatusCode.Forbidden
                         }
                     }
+                    it("should return status ${HttpStatusCode.InternalServerError} if person is null from pdl") {
+                        with(
+                            handleRequest(HttpMethod.Get, url) {
+                                addHeader(Authorization, bearerHeader(validToken))
+                                addHeader(NAV_PERSONIDENT_HEADER, UserConstants.ARBEIDSTAKER_PDL_ERROR.value)
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.InternalServerError
+                        }
+                    }
                 }
             }
         }

--- a/src/test/kotlin/no/nav/syfo/person/api/PersonAdresseApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/person/api/PersonAdresseApiSpek.kt
@@ -57,9 +57,9 @@ class PersonAdresseApiSpek : Spek({
                             val personAdresseResponse: PersonAdresseResponse =
                                 objectMapper.readValue(response.content!!)
                             personAdresseResponse.navn shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.hentPerson?.fullName
-                            personAdresseResponse.bostedsadresse shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.hentPerson?.getBostedsadresse
-                            personAdresseResponse.kontaktadresse shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.hentPerson?.getKontaktadresse
-                            personAdresseResponse.oppholdsadresse shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.hentPerson?.getOppholdsadresse
+                            personAdresseResponse.bostedsadresse shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.hentPerson?.getBostedsadresse()
+                            personAdresseResponse.kontaktadresse shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.hentPerson?.getKontaktadresse()
+                            personAdresseResponse.oppholdsadresse shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.hentPerson?.getOppholdsadresse()
                         }
                     }
                 }

--- a/src/test/kotlin/no/nav/syfo/person/api/PersonAdresseApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/person/api/PersonAdresseApiSpek.kt
@@ -56,10 +56,10 @@ class PersonAdresseApiSpek : Spek({
                             response.status() shouldBeEqualTo HttpStatusCode.OK
                             val personAdresseResponse: PersonAdresseResponse =
                                 objectMapper.readValue(response.content!!)
-                            personAdresseResponse.navn shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.getFullName()
-                            personAdresseResponse.bostedsadresse shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.bostedsadresse()
-                            personAdresseResponse.kontaktadresse shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.kontaktadresse()
-                            personAdresseResponse.oppholdsadresse shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.oppholdsadresse()
+                            personAdresseResponse.navn shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.hentPerson?.fullName
+                            personAdresseResponse.bostedsadresse shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.hentPerson?.getBostedsadresse
+                            personAdresseResponse.kontaktadresse shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.hentPerson?.getKontaktadresse
+                            personAdresseResponse.oppholdsadresse shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.hentPerson?.getOppholdsadresse
                         }
                     }
                 }

--- a/src/test/kotlin/no/nav/syfo/person/api/PersonAdresseApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/person/api/PersonAdresseApiSpek.kt
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import io.ktor.http.*
 import io.ktor.http.HttpHeaders.Authorization
 import io.ktor.server.testing.*
-import no.nav.syfo.client.pdl.*
 import no.nav.syfo.person.api.domain.PersonAdresseResponse
 import no.nav.syfo.testhelper.*
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_PERSONIDENT
@@ -57,9 +56,9 @@ class PersonAdresseApiSpek : Spek({
                             val personAdresseResponse: PersonAdresseResponse =
                                 objectMapper.readValue(response.content!!)
                             personAdresseResponse.navn shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.hentPerson?.fullName
-                            personAdresseResponse.bostedsadresse shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.hentPerson?.getBostedsadresse()
-                            personAdresseResponse.kontaktadresse shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.hentPerson?.getKontaktadresse()
-                            personAdresseResponse.oppholdsadresse shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.hentPerson?.getOppholdsadresse()
+                            personAdresseResponse.bostedsadresse shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.hentPerson?.hentBostedsadresse()
+                            personAdresseResponse.kontaktadresse shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.hentPerson?.hentKontaktadresse()
+                            personAdresseResponse.oppholdsadresse shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.hentPerson?.hentOppholdsadresse()
                         }
                     }
                 }

--- a/src/test/kotlin/no/nav/syfo/person/api/PersonBrukerinfoApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/person/api/PersonBrukerinfoApiSpek.kt
@@ -98,7 +98,7 @@ class PersonBrukerinfoApiSpek : Spek({
                             response.status() shouldBeEqualTo HttpStatusCode.OK
                             val syfomodiapersonBrukerinfo: SyfomodiapersonBrukerinfo =
                                 objectMapper.readValue(response.content!!)
-                            syfomodiapersonBrukerinfo.tilrettelagtKommunikasjon?.talesprakTolk?.value shouldBeEqualTo "Norsk (NO)"
+                            syfomodiapersonBrukerinfo.tilrettelagtKommunikasjon?.talesprakTolk?.value shouldBeEqualTo "NO"
                             syfomodiapersonBrukerinfo.tilrettelagtKommunikasjon?.tegnsprakTolk?.value shouldBeEqualTo null
                         }
                     }

--- a/src/test/kotlin/no/nav/syfo/person/api/PersonBrukerinfoApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/person/api/PersonBrukerinfoApiSpek.kt
@@ -8,6 +8,7 @@ import io.ktor.server.testing.*
 import no.nav.syfo.person.api.domain.syfomodiaperson.SyfomodiapersonBrukerinfo
 import no.nav.syfo.testhelper.*
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_DOD
+import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_PDL_ERROR
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_PERSONIDENT
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_TILRETTELAGT_KOMMUNIKASJON
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_VEILEDER_NO_ACCESS
@@ -127,6 +128,16 @@ class PersonBrukerinfoApiSpek : Spek({
                             }
                         ) {
                             response.status() shouldBeEqualTo HttpStatusCode.Forbidden
+                        }
+                    }
+                    it("should return status ${HttpStatusCode.InternalServerError} if person is null from pdl") {
+                        with(
+                            handleRequest(HttpMethod.Get, url) {
+                                addHeader(Authorization, bearerHeader(validToken))
+                                addHeader(NAV_PERSONIDENT_HEADER, ARBEIDSTAKER_PDL_ERROR.value)
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.InternalServerError
                         }
                     }
                 }

--- a/src/test/kotlin/no/nav/syfo/person/api/PersonBrukerinfoApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/person/api/PersonBrukerinfoApiSpek.kt
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import io.ktor.http.*
 import io.ktor.http.HttpHeaders.Authorization
 import io.ktor.server.testing.*
-import no.nav.syfo.client.pdl.getFullName
 import no.nav.syfo.person.api.domain.syfomodiaperson.SyfomodiapersonBrukerinfo
 import no.nav.syfo.testhelper.*
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_DOD
@@ -69,7 +68,7 @@ class PersonBrukerinfoApiSpek : Spek({
                             syfomodiapersonBrukerinfo.kontaktinfo.epost shouldBeEqualTo digitalKontaktinfoBolkKanVarslesTrue.epostadresse
                             syfomodiapersonBrukerinfo.kontaktinfo.tlf shouldBeEqualTo digitalKontaktinfoBolkKanVarslesTrue.mobiltelefonnummer
                             syfomodiapersonBrukerinfo.kontaktinfo.skalHaVarsel shouldBeEqualTo true
-                            syfomodiapersonBrukerinfo.navn shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.getFullName()
+                            syfomodiapersonBrukerinfo.navn shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.hentPerson?.fullName
                             syfomodiapersonBrukerinfo.dodsdato shouldBe null
                             syfomodiapersonBrukerinfo.tilrettelagtKommunikasjon shouldBe null
                         }
@@ -84,7 +83,7 @@ class PersonBrukerinfoApiSpek : Spek({
                             response.status() shouldBeEqualTo HttpStatusCode.OK
                             val syfomodiapersonBrukerinfo: SyfomodiapersonBrukerinfo =
                                 objectMapper.readValue(response.content!!)
-                            syfomodiapersonBrukerinfo.navn shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.getFullName()
+                            syfomodiapersonBrukerinfo.navn shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.hentPerson?.fullName
                             syfomodiapersonBrukerinfo.dodsdato shouldBeEqualTo LocalDate.now()
                         }
                     }

--- a/src/test/kotlin/no/nav/syfo/person/api/PersonNavnApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/person/api/PersonNavnApiSpek.kt
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import io.ktor.http.*
 import io.ktor.http.HttpHeaders.Authorization
 import io.ktor.server.testing.*
-import no.nav.syfo.client.pdl.getFullName
 import no.nav.syfo.person.api.domain.FnrMedNavn
 import no.nav.syfo.testhelper.*
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_PERSONIDENT
@@ -56,7 +55,7 @@ class PersonNavnApiSpek : Spek({
                             response.status() shouldBeEqualTo HttpStatusCode.OK
                             val fnrMedNavn: FnrMedNavn = objectMapper.readValue(response.content!!)
                             fnrMedNavn.fnr shouldBeEqualTo ARBEIDSTAKER_PERSONIDENT.value
-                            fnrMedNavn.navn shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.getFullName()
+                            fnrMedNavn.navn shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.hentPerson?.fullName
                         }
                     }
                 }

--- a/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
@@ -11,6 +11,7 @@ object UserConstants {
     val ARBEIDSTAKER_ADRESSEBESKYTTET = PersonIdentNumber(ARBEIDSTAKER_PERSONIDENT.value.replace("2", "6"))
     val ARBEIDSTAKER_DOD = PersonIdentNumber(ARBEIDSTAKER_PERSONIDENT.value.replace("2", "7"))
     val ARBEIDSTAKER_TILRETTELAGT_KOMMUNIKASJON = PersonIdentNumber(ARBEIDSTAKER_PERSONIDENT.value.replace("2", "8"))
+    val ARBEIDSTAKER_PDL_ERROR = PersonIdentNumber(ARBEIDSTAKER_PERSONIDENT.value.replace("2", "9"))
 
     const val PERSON_TLF = "12345678"
     const val PERSON_EMAIL = "test@nav.no"

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/PdlMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/PdlMock.kt
@@ -72,7 +72,7 @@ fun generatePdlHentPerson(
 
 private fun generatePdlTilrettelagtKommunikasjon(): PdlTilrettelagtKommunikasjon =
     PdlTilrettelagtKommunikasjon(
-        talespraaktolk = PdlSprak(spraak = "Norsk (NO)"),
+        talespraaktolk = PdlSprak(spraak = "NO"),
         tegnspraaktolk = PdlSprak(spraak = null),
     )
 

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/PdlMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/PdlMock.kt
@@ -11,6 +11,7 @@ import no.nav.syfo.client.pdl.*
 import no.nav.syfo.testhelper.UserConstants
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_ADRESSEBESKYTTET
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_DOD
+import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_PDL_ERROR
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_TILRETTELAGT_KOMMUNIKASJON
 import no.nav.syfo.testhelper.getRandomPort
 import java.time.LocalDate
@@ -27,6 +28,11 @@ fun generatePdlPersonResponse(
         doedsdato = doedsdato,
         tilrettelagtKommunikasjon = tilrettelagtKommunikasjon,
     )
+)
+
+fun generatePdlPersonResponseError() = PdlPersonResponse(
+    errors = null,
+    data = null,
 )
 
 fun generatePdlPersonNavn(): PdlPersonNavn {
@@ -97,6 +103,8 @@ class PdlMock {
                         generatePdlPersonResponse(doedsdato = LocalDate.now())
                     } else if (ARBEIDSTAKER_TILRETTELAGT_KOMMUNIKASJON.value == pdlRequest.variables.ident) {
                         generatePdlPersonResponse(tilrettelagtKommunikasjon = generatePdlTilrettelagtKommunikasjon())
+                    } else if (ARBEIDSTAKER_PDL_ERROR.value == pdlRequest.variables.ident) {
+                        generatePdlPersonResponseError()
                     } else {
                         personResponseDefault
                     }


### PR DESCRIPTION
Gjorde at alle funksjoner som gjorde operasjoner på `PdlPerson` høres til denne data classen i stedet for `PdlHentPerson` ettersom vi i `PdlHentPerson` ikke vet om `PdlPerson` verdien finnes eller ikke.

- [x] Sjekk at dette blir håndtert riktig i frontend
