### PR TITLE
IS-1907: Cache adressebeskyttelse and remove unused field from dto

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
@@ -60,6 +60,7 @@ fun Application.apiModule(
     )
     val pdlClient = PdlClient(
         azureAdClient = azureAdClient,
+        redisStore = redisStore,
         baseUrl = environment.pdlUrl,
         clientId = environment.pdlClientId,
     )
@@ -71,6 +72,7 @@ fun Application.apiModule(
     )
     val skjermingskodeService = SkjermingskodeService(
         skjermedePersonerPipClient = skjermedePersonerPipClient,
+        pdlClient = pdlClient,
     )
     val veilederTilgangskontrollClient = VeilederTilgangskontrollClient(
         azureAdClient = azureAdClient,

--- a/src/main/kotlin/no/nav/syfo/client/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/PdlClient.kt
@@ -108,7 +108,7 @@ class PdlClient(
 
     companion object {
         const val CACHE_ADRESSEBESKYTTELSE_PERSON_KEY_PREFIX = "adressebeskyttelse-person-"
-        const val CACHE_ADRESSEBESKYTTELSE_PERSON_EXPIRE_SECONDS = 60 * 60L
+        const val CACHE_ADRESSEBESKYTTELSE_PERSON_EXPIRE_SECONDS = 12 * 60 * 60L
 
         private val log = LoggerFactory.getLogger(PdlClient::class.java)
     }

--- a/src/main/kotlin/no/nav/syfo/client/pdl/PdlClientMetric.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/PdlClientMetric.kt
@@ -10,9 +10,19 @@ const val CALL_PDL_PERSON_BASE = "${CALL_PDL_BASE}_person"
 const val CALL_PDL_PERSON_SUCCESS = "${CALL_PDL_PERSON_BASE}_success_count"
 const val CALL_PDL_PERSON_FAIL = "${CALL_PDL_PERSON_BASE}_fail_count"
 
+const val CALL_PDL_ADRESSEBESKYTTELSE_CACHE_HIT = "${CALL_PDL_PERSON_BASE}_adressebeskyttelse_cache_hit_count"
+const val CALL_PDL_ADRESSEBESKYTTELSE_CACHE_MISS = "${CALL_PDL_PERSON_BASE}_adressebeskyttelse_cache_miss_count"
+
 val COUNT_CALL_PDL_PERSON_SUCCESS: Counter = Counter.builder(CALL_PDL_PERSON_SUCCESS)
     .description("Counts the number of successful calls to persondatalosning - person")
     .register(METRICS_REGISTRY)
 val COUNT_CALL_PDL_PERSON_FAIL: Counter = Counter.builder(CALL_PDL_PERSON_FAIL)
     .description("Counts the number of failed calls to persondatalosning - person")
+    .register(METRICS_REGISTRY)
+
+val COUNT_CALL_PDL_ADRESSEBESKYTTELSE_CACHE_HIT: Counter = Counter.builder(CALL_PDL_ADRESSEBESKYTTELSE_CACHE_HIT)
+    .description("Counts the number of cache hits for calls to pdl - person adressebeskyttelse")
+    .register(METRICS_REGISTRY)
+val COUNT_CALL_PDL_ADRESSEBESKYTTELSE_CACHE_MISS: Counter = Counter.builder(CALL_PDL_ADRESSEBESKYTTELSE_CACHE_MISS)
+    .description("Counts the number of cache misses for calls to pdl - person adressebeskyttelse")
     .register(METRICS_REGISTRY)

--- a/src/main/kotlin/no/nav/syfo/person/api/PersonAPI.kt
+++ b/src/main/kotlin/no/nav/syfo/person/api/PersonAPI.kt
@@ -53,22 +53,15 @@ fun Route.registrerPersonApi(
                 )
                 val response: List<PersonInfo> = grantedAccessList
                     .mapNotNull { personIdentNumber ->
-                        val person = pdlClient.person(
+                        val skjermingskode = skjermingskodeService.hentBrukersSkjermingskode(
                             callId = callId,
-                            personIdentNumber = personIdentNumber,
+                            personIdent = personIdentNumber,
+                            token = token,
                         )
-                        person?.hentPerson?.let {
-                            val skjermingskode = skjermingskodeService.hentBrukersSkjermingskode(
-                                callId = callId,
-                                person = it,
-                                personIdent = personIdentNumber,
-                                token = token,
-                            )
+                        skjermingskode?.let {
                             PersonInfo(
                                 fnr = personIdentNumber.value,
-                                navn = it.fullName ?: "",
                                 skjermingskode = skjermingskode,
-                                dodsdato = it.dodsdato,
                             )
                         }
                     }

--- a/src/main/kotlin/no/nav/syfo/person/api/domain/PersonInfo.kt
+++ b/src/main/kotlin/no/nav/syfo/person/api/domain/PersonInfo.kt
@@ -1,10 +1,6 @@
 package no.nav.syfo.person.api.domain
 
-import java.time.LocalDate
-
 data class PersonInfo(
     val fnr: String,
-    val navn: String,
     val skjermingskode: Skjermingskode,
-    val dodsdato: LocalDate? = null,
 )

--- a/src/main/kotlin/no/nav/syfo/person/skjermingskode/SkjermingskodeService.kt
+++ b/src/main/kotlin/no/nav/syfo/person/skjermingskode/SkjermingskodeService.kt
@@ -1,27 +1,32 @@
 package no.nav.syfo.person.skjermingskode
 
-import no.nav.syfo.client.pdl.PdlPerson
+import no.nav.syfo.client.pdl.PdlClient
 import no.nav.syfo.client.skjermedepersonerpip.SkjermedePersonerPipClient
 import no.nav.syfo.domain.PersonIdentNumber
 import no.nav.syfo.person.api.domain.Skjermingskode
 
 class SkjermingskodeService(
     private val skjermedePersonerPipClient: SkjermedePersonerPipClient,
+    private val pdlClient: PdlClient,
 ) {
     suspend fun hentBrukersSkjermingskode(
         callId: String,
-        person: PdlPerson,
         personIdent: PersonIdentNumber,
         token: String,
-    ): Skjermingskode {
-        if (person.isKode6Or7)
-            return Skjermingskode.DISKRESJONSMERKET
-        return if (
-            skjermedePersonerPipClient.isSkjermet(
-                callId = callId,
-                personIdentNumber = personIdent,
-                token = token,
-            )
-        ) Skjermingskode.EGEN_ANSATT else Skjermingskode.INGEN
+    ): Skjermingskode? {
+        val hasAdressebeskyttelse = pdlClient.hasAdressebeskyttelse(callId = callId, personIdent = personIdent)
+
+        return hasAdressebeskyttelse?.let {
+            when {
+                hasAdressebeskyttelse -> Skjermingskode.DISKRESJONSMERKET
+                else -> if (
+                    skjermedePersonerPipClient.isSkjermet(
+                        callId = callId,
+                        personIdentNumber = personIdent,
+                        token = token,
+                    )
+                ) Skjermingskode.EGEN_ANSATT else Skjermingskode.INGEN
+            }
+        }
     }
 }

--- a/src/test/kotlin/no/nav/syfo/client/pdl/PdlClientSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/client/pdl/PdlClientSpek.kt
@@ -1,0 +1,104 @@
+package no.nav.syfo.client.pdl
+
+import io.mockk.*
+import kotlinx.coroutines.runBlocking
+import no.nav.syfo.application.cache.RedisStore
+import no.nav.syfo.client.azuread.AzureAdClient
+import no.nav.syfo.client.azuread.AzureAdToken
+import no.nav.syfo.testhelper.ExternalMockEnvironment
+import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_ADRESSEBESKYTTET
+import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_PERSONIDENT
+import no.nav.syfo.testhelper.startExternalMocks
+import no.nav.syfo.testhelper.stopExternalMocks
+import org.amshove.kluent.shouldBeEqualTo
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.time.LocalDateTime
+
+class PdlClientSpek : Spek({
+
+    val externalMockEnvironment = ExternalMockEnvironment()
+    val cacheMock = mockk<RedisStore>(relaxed = true)
+    val azureAdClient = mockk<AzureAdClient>()
+    val pdlClient = PdlClient(
+        azureAdClient = azureAdClient,
+        redisStore = cacheMock,
+        baseUrl = externalMockEnvironment.pdlMock.url,
+        clientId = externalMockEnvironment.environment.pdlClientId,
+    )
+
+    coEvery {
+        azureAdClient.getSystemToken(any())
+    } returns AzureAdToken(
+        accessToken = "token",
+        expires = LocalDateTime.now().plusDays(1)
+    )
+
+    beforeEachTest {
+        clearMocks(cacheMock)
+    }
+
+    beforeGroup {
+        externalMockEnvironment.startExternalMocks()
+    }
+
+    afterGroup {
+        externalMockEnvironment.stopExternalMocks()
+    }
+
+    describe("${PdlClient::class.java.simpleName} hasAdressebeskyttelse") {
+        it("hasAdressebeskyttelse returns true when cached value is true") {
+            every { cacheMock.getObject<Boolean>(any()) } returns true
+
+            runBlocking {
+                pdlClient.hasAdressebeskyttelse(
+                    personIdent = ARBEIDSTAKER_ADRESSEBESKYTTET,
+                    callId = "callId",
+                ) shouldBeEqualTo true
+            }
+            verify(exactly = 1) { cacheMock.getObject<Boolean>(any()) }
+            verify(exactly = 0) { cacheMock.setObject<Boolean>(any(), any(), any()) }
+        }
+
+        it("hasAdressebeskyttelse returns false when cached value is false") {
+            every { cacheMock.getObject<Boolean>(any()) } returns false
+
+            runBlocking {
+                pdlClient.hasAdressebeskyttelse(
+                    personIdent = ARBEIDSTAKER_PERSONIDENT,
+                    callId = "callId",
+                ) shouldBeEqualTo false
+            }
+            verify(exactly = 1) { cacheMock.getObject<Boolean>(any()) }
+            verify(exactly = 0) { cacheMock.setObject<Boolean>(any(), any(), any()) }
+        }
+
+        it("hasAdressebeskyttelse returns false and caches value when no cached value and arbeidstaker ikke adressebeskyttet") {
+            every { cacheMock.getObject<Boolean>(any()) } returns null
+            justRun { cacheMock.setObject<Boolean>(any(), any(), any()) }
+
+            runBlocking {
+                pdlClient.hasAdressebeskyttelse(
+                    personIdent = ARBEIDSTAKER_PERSONIDENT,
+                    callId = "callId",
+                ) shouldBeEqualTo false
+            }
+            verify(exactly = 1) { cacheMock.getObject<Boolean>(any()) }
+            verify(exactly = 1) { cacheMock.setObject<Boolean>(any(), any(), any()) }
+        }
+
+        it("hasAdressebeskyttelse returns true and caches value when no cached value and arbeidstaker adressebeskyttet") {
+            every { cacheMock.getObject<Boolean>(any()) } returns null
+            justRun { cacheMock.setObject<Boolean>(any(), any(), any()) }
+
+            runBlocking {
+                pdlClient.hasAdressebeskyttelse(
+                    personIdent = ARBEIDSTAKER_ADRESSEBESKYTTET,
+                    callId = "callId",
+                ) shouldBeEqualTo true
+            }
+            verify(exactly = 1) { cacheMock.getObject<Boolean>(any()) }
+            verify(exactly = 1) { cacheMock.setObject<Boolean>(any(), any(), any()) }
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/client/pdl/PdlClientSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/client/pdl/PdlClientSpek.kt
@@ -7,10 +7,12 @@ import no.nav.syfo.client.azuread.AzureAdClient
 import no.nav.syfo.client.azuread.AzureAdToken
 import no.nav.syfo.testhelper.ExternalMockEnvironment
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_ADRESSEBESKYTTET
+import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_PDL_ERROR
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_PERSONIDENT
 import no.nav.syfo.testhelper.startExternalMocks
 import no.nav.syfo.testhelper.stopExternalMocks
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import java.time.LocalDateTime
@@ -99,6 +101,20 @@ class PdlClientSpek : Spek({
             }
             verify(exactly = 1) { cacheMock.getObject<Boolean>(any()) }
             verify(exactly = 1) { cacheMock.setObject<Boolean>(any(), any(), any()) }
+        }
+
+        it("hasAdressebeskyttelse returns null and doesnt cache when arbeidstaker returns error from pdl") {
+            every { cacheMock.getObject<Boolean>(any()) } returns null
+            justRun { cacheMock.setObject<Boolean>(any(), any(), any()) }
+
+            runBlocking {
+                pdlClient.hasAdressebeskyttelse(
+                    personIdent = ARBEIDSTAKER_PDL_ERROR,
+                    callId = "callId",
+                ).shouldBeNull()
+            }
+            verify(exactly = 1) { cacheMock.getObject<Boolean>(any()) }
+            verify(exactly = 0) { cacheMock.setObject<Boolean>(any(), any(), any()) }
         }
     }
 })

--- a/src/test/kotlin/no/nav/syfo/person/api/PersonInfoApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/person/api/PersonInfoApiSpek.kt
@@ -9,6 +9,7 @@ import no.nav.syfo.person.api.domain.*
 import no.nav.syfo.testhelper.*
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_ADRESSEBESKYTTET
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_ALTERNATIVE_PERSONIDENT
+import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_PDL_ERROR
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_PERSONIDENT
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_VEILEDER_NO_ACCESS
 import no.nav.syfo.util.*
@@ -53,6 +54,7 @@ class PersonInfoApiSpek : Spek({
                             PersonInfoRequest(ARBEIDSTAKER_ALTERNATIVE_PERSONIDENT.value),
                             PersonInfoRequest(ARBEIDSTAKER_ADRESSEBESKYTTET.value),
                             PersonInfoRequest(ARBEIDSTAKER_VEILEDER_NO_ACCESS.value),
+                            PersonInfoRequest(ARBEIDSTAKER_PDL_ERROR.value)
                         )
                         with(
                             handleRequest(HttpMethod.Post, url) {
@@ -65,10 +67,9 @@ class PersonInfoApiSpek : Spek({
                             response.status() shouldBeEqualTo HttpStatusCode.OK
                             val personInfoList: List<PersonInfo> =
                                 objectMapper.readValue(response.content!!)
-                            personInfoList.size shouldBeEqualTo requestBody.size - 1
+                            personInfoList.size shouldBeEqualTo requestBody.size - 2 // Should not contain info for ARBEIDSTAKER_VEILEDER_NO_ACCESS and ARBEIDSTAKER_PDL_ERROR
                             personInfoList[0].fnr shouldBeEqualTo ARBEIDSTAKER_PERSONIDENT.value
                             personInfoList[0].skjermingskode shouldBeEqualTo Skjermingskode.EGEN_ANSATT
-                            personInfoList[0].navn shouldBeEqualTo "${UserConstants.PERSON_NAME_FIRST} ${UserConstants.PERSON_NAME_MIDDLE} ${UserConstants.PERSON_NAME_LAST}"
                             personInfoList[1].fnr shouldBeEqualTo ARBEIDSTAKER_ALTERNATIVE_PERSONIDENT.value
                             personInfoList[1].skjermingskode shouldBeEqualTo Skjermingskode.INGEN
                             personInfoList[2].fnr shouldBeEqualTo ARBEIDSTAKER_ADRESSEBESKYTTET.value

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/VeilederTilgangskontrollMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/VeilederTilgangskontrollMock.kt
@@ -13,6 +13,7 @@ import no.nav.syfo.client.veiledertilgang.VeilederTilgangskontrollClient.Compani
 import no.nav.syfo.testhelper.UserConstants
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_ADRESSEBESKYTTET
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_ALTERNATIVE_PERSONIDENT
+import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_PDL_ERROR
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_PERSONIDENT
 import no.nav.syfo.testhelper.getRandomPort
 import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
@@ -53,6 +54,7 @@ class VeilederTilgangskontrollMock {
                         ARBEIDSTAKER_PERSONIDENT.value,
                         ARBEIDSTAKER_ALTERNATIVE_PERSONIDENT.value,
                         ARBEIDSTAKER_ADRESSEBESKYTTET.value,
+                        ARBEIDSTAKER_PDL_ERROR.value,
                     )
                 )
             }


### PR DESCRIPTION
`person/info`-api skal brukes av syfooversikt til å hente skjermingskode for liste av personer (pdd er kallet i syfooversikt skrudd av pga dårlig ytelse). Legger til caching av adressebeskyttelse (kode6/7) for kallet til pdl som brukes av dette apiet. Fjerner samtidig noen felter fra dtoen som returneres fra api-et da disse ikke lenger brukes i syfooversikt.