### PR TITLE
IS-1848: Add KodeverkClient

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -45,6 +45,7 @@ spec:
     outbound:
       external:
         - host: "pdl-api.dev-fss-pub.nais.io"
+        - host: "kodeverk.dev-fss-pub.nais.io"
       rules:
         - application: syfoperson-redis
         - application: istilgangskontroll
@@ -81,3 +82,5 @@ spec:
       value: "dev-gcp.teamsykefravr.istilgangskontroll"
     - name: ISTILGANGSKONTROLL_URL
       value: "http://istilgangskontroll"
+    - name: KODEVERK_URL
+      value: "https://kodeverk.dev-fss-pub.nais.io"

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -45,6 +45,7 @@ spec:
     outbound:
       external:
         - host: "pdl-api.prod-fss-pub.nais.io"
+        - host: "kodeverk.prod-fss-pub.nais.io"
       rules:
         - application: syfoperson-redis
         - application: istilgangskontroll
@@ -81,3 +82,5 @@ spec:
       value: "prod-gcp.teamsykefravr.istilgangskontroll"
     - name: ISTILGANGSKONTROLL_URL
       value: "http://istilgangskontroll"
+    - name: KODEVERK_URL
+      value: "https://kodeverk.prod-fss-pub.nais.io"

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -18,6 +18,8 @@ data class Environment(
     val istilgangskontrollUrl: String = getEnvVar("ISTILGANGSKONTROLL_URL"),
     val istilgangskontrollClientId: String = getEnvVar("ISTILGANGSKONTROLL_CLIENT_ID"),
 
+    val kodeverkUrl: String = getEnvVar("KODEVERK_URL"),
+
     val redisHost: String = getEnvVar("REDIS_HOST"),
     val redisPort: Int = getEnvVar("REDIS_PORT", "6379").toInt(),
     val redisSecret: String = getEnvVar("REDIS_PASSWORD"),

--- a/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
@@ -9,6 +9,7 @@ import no.nav.syfo.application.api.authentication.*
 import no.nav.syfo.application.cache.RedisStore
 import no.nav.syfo.application.metric.api.registerMetricApi
 import no.nav.syfo.client.azuread.AzureAdClient
+import no.nav.syfo.client.kodeverk.KodeverkClient
 import no.nav.syfo.client.krr.KRRClient
 import no.nav.syfo.client.pdl.PdlClient
 import no.nav.syfo.client.skjermedepersonerpip.SkjermedePersonerPipClient
@@ -80,6 +81,11 @@ fun Application.apiModule(
         clientId = environment.istilgangskontrollClientId,
     )
 
+    val kodeverkClient = KodeverkClient(
+        redisStore = redisStore,
+        baseUrl = environment.kodeverkUrl,
+    )
+
     routing {
         registerPodApi(
             applicationState = applicationState,
@@ -92,6 +98,7 @@ fun Application.apiModule(
                 skjermingskodeService = skjermingskodeService,
                 skjermedePersonerPipClient = skjermedePersonerPipClient,
                 veilederTilgangskontrollClient = veilederTilgangskontrollClient,
+                kodeverkClient = kodeverkClient,
             )
         }
     }

--- a/src/main/kotlin/no/nav/syfo/application/cache/RedisStore.kt
+++ b/src/main/kotlin/no/nav/syfo/application/cache/RedisStore.kt
@@ -18,6 +18,18 @@ class RedisStore(
         }
     }
 
+    inline fun <reified T> getListObject(key: String): List<T>? {
+        val value = get(key)
+        return if (value != null) {
+            objectMapper.readValue(
+                value,
+                objectMapper.typeFactory.constructCollectionType(ArrayList::class.java, T::class.java)
+            )
+        } else {
+            null
+        }
+    }
+
     fun get(
         key: String,
     ): String? {

--- a/src/main/kotlin/no/nav/syfo/client/kodeverk/KodeverkBetydninger.kt
+++ b/src/main/kotlin/no/nav/syfo/client/kodeverk/KodeverkBetydninger.kt
@@ -1,0 +1,25 @@
+package no.nav.syfo.client.kodeverk
+
+data class KodeverkBetydninger(
+    val betydninger: Map<String, List<Betydning>>,
+) {
+    fun toPostInformasjonListe(): List<Postinformasjon> {
+        return betydninger.map {
+            Postinformasjon(
+                postnummer = it.key,
+                poststed = it.value.first().beskrivelser["nb"]?.term,
+            )
+        }
+    }
+}
+
+data class Betydning(
+    val gyldigTil: String, // Trengs ikke
+    val gyldigFra: String, // Trengs ikke
+    val beskrivelser: Map<String, Beskrivelse>,
+)
+
+data class Beskrivelse(
+    val term: String,
+    val tekst: String, // Trengs ikke
+)

--- a/src/main/kotlin/no/nav/syfo/client/kodeverk/KodeverkClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/kodeverk/KodeverkClient.kt
@@ -1,0 +1,98 @@
+package no.nav.syfo.client.kodeverk
+
+import io.ktor.client.call.*
+import io.ktor.client.plugins.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import kotlinx.coroutines.channels.ClosedReceiveChannelException
+import net.logstash.logback.argument.StructuredArguments
+import no.nav.syfo.application.cache.RedisStore
+import no.nav.syfo.client.httpClientDefault
+import no.nav.syfo.util.*
+import org.slf4j.LoggerFactory
+import java.time.LocalDate
+
+class KodeverkClient(
+    private val redisStore: RedisStore,
+    private val baseUrl: String,
+) {
+    private val httpClient = httpClientDefault()
+
+    suspend fun getPostinformasjon(
+        callId: String,
+    ): List<Postinformasjon> {
+        val cachedValue = redisStore.getListObject<Postinformasjon>(CACHE_POSTINFORMASJON_KEY)
+
+        if (!cachedValue.isNullOrEmpty()) {
+            return cachedValue
+        } else {
+            val postinformasjon = getPostnummerKodeverk(
+                callId = callId,
+            )
+            if (postinformasjon.isNotEmpty()) {
+                redisStore.setObject(
+                    expireSeconds = CACHE_KODEVERK_POSTINFORMASJON_EXPIRE_SECONDS,
+                    key = CACHE_POSTINFORMASJON_KEY,
+                    value = postinformasjon,
+                )
+            }
+
+            return postinformasjon
+        }
+    }
+
+    private suspend fun getPostnummerKodeverk(
+        callId: String,
+    ): List<Postinformasjon> {
+        val postnummerUrl = "$baseUrl$KODEVERK_POSTNUMMER_BETYDNINGER_PATH"
+        return try {
+            val response: HttpResponse = httpClient.get(postnummerUrl) {
+                parameter(KODEVERK_EKSKLUDER_UGYLDIGE_PARAM, true)
+                parameter(KODEVERK_OPPSLAGSDATO_PARAM, "${LocalDate.now()}")
+                parameter(KODEVERK_SPRAK_PARAM, "nb")
+                header(NAV_CALL_ID_HEADER, callId)
+                header(NAV_CONSUMER_ID_HEADER, "srvsyfoperson")
+                accept(ContentType.Application.Json)
+            }
+            COUNT_CALL_KODEVERK_POSTNUMMER_SUCCESS.increment()
+            val body = response.body<KodeverkBetydninger>()
+            body.toPostInformasjonListe()
+        } catch (e: ClientRequestException) {
+            handleUnexpectedResponseException(e.response, callId)
+            emptyList()
+        } catch (e: ServerResponseException) {
+            handleUnexpectedResponseException(e.response, callId)
+            emptyList()
+        } catch (e: ClosedReceiveChannelException) {
+            log.error("ClosedReceiveChannelException while requesting Postnummer from kodeverk", e)
+            COUNT_CALL_KODEVERK_POSTNUMMER_FAIL.increment()
+            emptyList()
+        }
+    }
+
+    private fun handleUnexpectedResponseException(
+        response: HttpResponse,
+        callId: String,
+    ) {
+        log.error(
+            "Error while requesting access to Postnummer from kodeverk with {}, {}",
+            StructuredArguments.keyValue("statusCode", response.status.value.toString()),
+            callIdArgument(callId)
+        )
+        COUNT_CALL_KODEVERK_POSTNUMMER_FAIL.increment()
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(KodeverkClient::class.java)
+
+        const val CACHE_POSTINFORMASJON_KEY = "postinformasjon"
+        const val CACHE_KODEVERK_POSTINFORMASJON_EXPIRE_SECONDS = 60 * 60 * 24L
+
+        private const val KODEVERK_COMMON_PATH = "/api/v1/kodeverk"
+        const val KODEVERK_POSTNUMMER_BETYDNINGER_PATH = "$KODEVERK_COMMON_PATH/Postnummer/koder/betydninger"
+        private const val KODEVERK_EKSKLUDER_UGYLDIGE_PARAM = "ekskluderUgyldige"
+        private const val KODEVERK_OPPSLAGSDATO_PARAM = "oppslagsdato"
+        private const val KODEVERK_SPRAK_PARAM = "spraak"
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/client/kodeverk/KodeverkClientMetric.kt
+++ b/src/main/kotlin/no/nav/syfo/client/kodeverk/KodeverkClientMetric.kt
@@ -1,0 +1,16 @@
+package no.nav.syfo.client.kodeverk
+
+import io.micrometer.core.instrument.Counter
+import no.nav.syfo.application.metric.METRICS_NS
+import no.nav.syfo.application.metric.METRICS_REGISTRY
+
+const val CALL_KODEVERK_POSTNUMMER_BASE = "${METRICS_NS}_call_kodeverk_postnummer"
+const val CALL_KODEVERK_POSTNUMMER_SUCCESS = "${CALL_KODEVERK_POSTNUMMER_BASE}_success_count"
+const val CALL_KODEVERK_POSTNUMMER_FAIL = "${CALL_KODEVERK_POSTNUMMER_BASE}_fail_count"
+
+val COUNT_CALL_KODEVERK_POSTNUMMER_SUCCESS: Counter = Counter.builder(CALL_KODEVERK_POSTNUMMER_SUCCESS)
+    .description("Counts the number of successful calls to kodeverk - postnummer")
+    .register(METRICS_REGISTRY)
+val COUNT_CALL_KODEVERK_POSTNUMMER_FAIL: Counter = Counter.builder(CALL_KODEVERK_POSTNUMMER_FAIL)
+    .description("Counts the number of failed calls to kodeverk - postnummer")
+    .register(METRICS_REGISTRY)

--- a/src/main/kotlin/no/nav/syfo/client/kodeverk/Postinformasjon.kt
+++ b/src/main/kotlin/no/nav/syfo/client/kodeverk/Postinformasjon.kt
@@ -1,0 +1,6 @@
+package no.nav.syfo.client.kodeverk
+
+data class Postinformasjon(
+    val postnummer: String,
+    val poststed: String?, // TODO: Skal vi godta at denne er null?
+)

--- a/src/main/kotlin/no/nav/syfo/person/api/PersonAPI.kt
+++ b/src/main/kotlin/no/nav/syfo/person/api/PersonAPI.kt
@@ -5,6 +5,7 @@ import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import no.nav.syfo.client.kodeverk.KodeverkClient
 import no.nav.syfo.client.krr.KRRClient
 import no.nav.syfo.client.krr.toSyfomodiapersonKontaktinfo
 import no.nav.syfo.client.pdl.*
@@ -33,6 +34,7 @@ fun Route.registrerPersonApi(
     skjermingskodeService: SkjermingskodeService,
     skjermedePersonerPipClient: SkjermedePersonerPipClient,
     veilederTilgangskontrollClient: VeilederTilgangskontrollClient,
+    kodeverkClient: KodeverkClient,
 ) {
     route(apiPersonBasePath) {
         post(apiPersonInfoPath) {

--- a/src/test/kotlin/no/nav/syfo/client/kodeverk/KodeverkClientSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/client/kodeverk/KodeverkClientSpek.kt
@@ -1,0 +1,88 @@
+package no.nav.syfo.client.kodeverk
+
+import io.mockk.*
+import kotlinx.coroutines.runBlocking
+import no.nav.syfo.application.cache.RedisStore
+import no.nav.syfo.testhelper.*
+import org.amshove.kluent.shouldBeEqualTo
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class KodeverkClientSpek : Spek({
+
+    val externalMockEnvironment = ExternalMockEnvironment()
+    val redisStore = mockk<RedisStore>(relaxed = true)
+    val kodeverkClient = KodeverkClient(
+        redisStore = redisStore,
+        baseUrl = externalMockEnvironment.kodeverkMock.url,
+    )
+
+    beforeEachTest {
+        clearMocks(redisStore)
+    }
+
+    beforeGroup {
+        externalMockEnvironment.startExternalMocks()
+    }
+
+    afterGroup {
+        externalMockEnvironment.stopExternalMocks()
+    }
+
+    describe("${KodeverkClient::class.java.simpleName} getPostInformasjon") {
+        val callId = "callId"
+
+        it("returns cached value") {
+            every { redisStore.getListObject<Postinformasjon>(any()) } returns postinformasjonList
+
+            runBlocking {
+                kodeverkClient.getPostinformasjon(callId) shouldBeEqualTo postinformasjonList
+            }
+
+            verify(exactly = 1) { redisStore.get(key = "postinformasjon") }
+            verify(exactly = 0) { redisStore.setObject<Postinformasjon>(any(), any(), any()) }
+        }
+
+        it("fetch postinformasjon from kodeverk and caches value when cache is empty") {
+            every { redisStore.getListObject<Postinformasjon>(any()) } returns null
+
+            runBlocking {
+                kodeverkClient.getPostinformasjon(callId) shouldBeEqualTo postinformasjonFromServerMock
+            }
+
+            verify(exactly = 1) { redisStore.get(key = "postinformasjon") }
+            verify(exactly = 1) {
+                redisStore.setObject(
+                    expireSeconds = 86400,
+                    key = "postinformasjon",
+                    value = postinformasjonFromServerMock,
+                )
+            }
+        }
+
+        it("Don't store empty list in cache if call to Kodeverk fails") {
+            every { redisStore.getListObject<Postinformasjon>(any()) } returns null
+
+            runBlocking {
+                kodeverkClient.getPostinformasjon(callId = "500")
+            }
+
+            verify(exactly = 1) { redisStore.get(key = "postinformasjon") }
+            verify(exactly = 0) { redisStore.setObject<Postinformasjon>(any(), any(), any()) }
+        }
+    }
+})
+
+val postinformasjonList = listOf<Postinformasjon>(
+    Postinformasjon(
+        postnummer = "9990",
+        poststed = "BÅTSFJORD",
+    ),
+)
+
+val postinformasjonFromServerMock = listOf(
+    Postinformasjon(
+        postnummer = "1001",
+        poststed = "OSLO",
+    )
+)

--- a/src/test/kotlin/no/nav/syfo/testhelper/ExternalMockEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/ExternalMockEnvironment.kt
@@ -11,6 +11,7 @@ class ExternalMockEnvironment {
     val pdlMock = PdlMock()
     val skjermedPersonerPipMock = SkjermedePersonerPipMock()
     val veilederTilgangskontrollMock = VeilederTilgangskontrollMock()
+    val kodeverkMock = KodeverkMock()
 
     val externalApplicationMockMap = hashMapOf(
         azureAdMock.name to azureAdMock.server,
@@ -18,6 +19,7 @@ class ExternalMockEnvironment {
         pdlMock.name to pdlMock.server,
         skjermedPersonerPipMock.name to skjermedPersonerPipMock.server,
         veilederTilgangskontrollMock.name to veilederTilgangskontrollMock.server,
+        kodeverkMock.name to kodeverkMock.server,
     )
 
     val environment = testEnvironment(
@@ -26,6 +28,7 @@ class ExternalMockEnvironment {
         pdlUrl = pdlMock.url,
         skjermedePersonerPipUrl = skjermedPersonerPipMock.url,
         istilgangskontrollUrl = veilederTilgangskontrollMock.url,
+        kodeverkUrl = kodeverkMock.url,
     )
 
     val redisServer = testRedis(

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
@@ -10,6 +10,7 @@ fun testEnvironment(
     pdlUrl: String = "pdl",
     skjermedePersonerPipUrl: String = "skjermedepersonerpip",
     istilgangskontrollUrl: String = "tilgangskontroll",
+    kodeverkUrl: String = "kodeverk",
 ) = Environment(
     azureAppClientId = "syfoperson-client-id",
     azureAppClientSecret = "syfoperson-secret",
@@ -23,6 +24,7 @@ fun testEnvironment(
     skjermedePersonerPipUrl = skjermedePersonerPipUrl,
     istilgangskontrollClientId = "dev-gcp.teamsykefravr.istilgangskontroll",
     istilgangskontrollUrl = istilgangskontrollUrl,
+    kodeverkUrl = kodeverkUrl,
     redisHost = "localhost",
     redisSecret = "password",
 )

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/KodeverkMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/KodeverkMock.kt
@@ -1,0 +1,55 @@
+package no.nav.syfo.testhelper.mock
+
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.engine.*
+import io.ktor.server.netty.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import no.nav.syfo.application.api.installContentNegotiation
+import no.nav.syfo.client.kodeverk.*
+import no.nav.syfo.client.kodeverk.KodeverkClient.Companion.KODEVERK_POSTNUMMER_BETYDNINGER_PATH
+import no.nav.syfo.testhelper.getRandomPort
+import no.nav.syfo.util.NAV_CALL_ID_HEADER
+
+class KodeverkMock {
+    private val port = getRandomPort()
+    val url = "http://localhost:$port"
+    val name = "kodeverk"
+
+    private val kodeverkResponse = KodeverkBetydninger(
+        betydninger = mapOf(
+            "1001" to listOf(
+                Betydning(
+                    gyldigFra = "1900-01-01",
+                    gyldigTil = "9999-12-31",
+                    beskrivelser = mapOf(
+                        "nb" to Beskrivelse(
+                            term = "OSLO",
+                            tekst = "OSLO",
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    val server = embeddedServer(
+        factory = Netty,
+        port = port,
+    ) {
+        installContentNegotiation()
+        routing {
+            get(KODEVERK_POSTNUMMER_BETYDNINGER_PATH) {
+                when {
+                    call.request.headers[NAV_CALL_ID_HEADER] == "500" -> {
+                        call.respond(HttpStatusCode.InternalServerError)
+                    }
+                    else -> {
+                        call.respond(kodeverkResponse)
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
It's needed for fetching poststed so we can display it in the personkort in syfomodiaperson.
The next step is to create a new Adresse object we can map this into before it's returned to frontend, instead of using pdl objects.