### PR TITLE
IS-1848: Add poststed to adresse

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/kodeverk/Postinformasjon.kt
+++ b/src/main/kotlin/no/nav/syfo/client/kodeverk/Postinformasjon.kt
@@ -2,5 +2,8 @@ package no.nav.syfo.client.kodeverk
 
 data class Postinformasjon(
     val postnummer: String,
-    val poststed: String?, // TODO: Skal vi godta at denne er null?
+    val poststed: String?,
 )
+
+fun List<Postinformasjon>.getPoststedByPostnummer(postnummer: String?): String? =
+    this.firstOrNull { it.postnummer == postnummer }?.poststed

--- a/src/main/kotlin/no/nav/syfo/client/pdl/PdlAdresser.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/PdlAdresser.kt
@@ -3,57 +3,57 @@ package no.nav.syfo.client.pdl
 import java.time.LocalDate
 import java.time.LocalDateTime
 
-data class Bostedsadresse(
+data class PdlBostedsadresse(
     val angittFlyttedato: LocalDate?,
     val gyldigFraOgMed: LocalDateTime?,
     val gyldigTilOgMed: LocalDateTime?,
     val coAdressenavn: String?,
-    val vegadresse: Vegadresse?,
-    val matrikkeladresse: Matrikkeladresse?,
-    val utenlandskAdresse: UtenlandskAdresse?,
-    val ukjentBosted: UkjentBosted?
+    val vegadresse: PdlVegadresse?,
+    val matrikkeladresse: PdlMatrikkeladresse?,
+    val utenlandskAdresse: PdlUtenlandskAdresse?,
+    val ukjentBosted: PdlUkjentBosted?
 )
 
-data class Kontaktadresse(
+data class PdlKontaktadresse(
     val gyldigFraOgMed: LocalDateTime?,
     val gyldigTilOgMed: LocalDateTime?,
-    val type: KontaktadresseType,
+    val type: PdlKontaktadresseType,
     val coAdressenavn: String?,
-    val postboksadresse: Postboksadresse?,
-    val vegadresse: Vegadresse?,
-    val postadresseIFrittFormat: PostadresseIFrittFormat?,
-    val utenlandskAdresse: UtenlandskAdresse?,
-    val utenlandskAdresseIFrittFormat: UtenlandskAdresseIFrittFormat?
+    val postboksadresse: PdlPostboksadresse?,
+    val vegadresse: PdlVegadresse?,
+    val postadresseIFrittFormat: PdlPostadresseIFrittFormat?,
+    val utenlandskAdresse: PdlUtenlandskAdresse?,
+    val utenlandskAdresseIFrittFormat: PdlUtenlandskAdresseIFrittFormat?
 )
 
-enum class KontaktadresseType {
+enum class PdlKontaktadresseType {
     Innland, Utland
 }
 
-data class Oppholdsadresse(
+data class PdlOppholdsadresse(
     val gyldigFraOgMed: LocalDateTime?,
     val gyldigTilOgMed: LocalDateTime?,
     val coAdressenavn: String?,
-    val utenlandskAdresse: UtenlandskAdresse?,
-    val vegadresse: Vegadresse?,
-    val matrikkeladresse: Matrikkeladresse?,
+    val utenlandskAdresse: PdlUtenlandskAdresse?,
+    val vegadresse: PdlVegadresse?,
+    val matrikkeladresse: PdlMatrikkeladresse?,
     val oppholdAnnetSted: String?
 )
 
-data class PostadresseIFrittFormat(
+data class PdlPostadresseIFrittFormat(
     val adresselinje1: String?,
     val adresselinje2: String?,
     val adresselinje3: String?,
     val postnummer: String?
 )
 
-data class Postboksadresse(
+data class PdlPostboksadresse(
     val postbokseier: String?,
     val postboks: String,
     val postnummer: String?
 )
 
-data class UtenlandskAdresse(
+data class PdlUtenlandskAdresse(
     val adressenavnNummer: String?,
     val bygningEtasjeLeilighet: String?,
     val postboksNummerNavn: String?,
@@ -63,7 +63,7 @@ data class UtenlandskAdresse(
     val landkode: String
 )
 
-data class UtenlandskAdresseIFrittFormat(
+data class PdlUtenlandskAdresseIFrittFormat(
     val adresselinje1: String?,
     val adresselinje2: String?,
     val adresselinje3: String?,
@@ -72,7 +72,7 @@ data class UtenlandskAdresseIFrittFormat(
     val landkode: String
 )
 
-data class Vegadresse(
+data class PdlVegadresse(
     val matrikkelId: Long?,
     val husnummer: String?,
     val husbokstav: String?,
@@ -84,7 +84,7 @@ data class Vegadresse(
     val postnummer: String?
 )
 
-data class Matrikkeladresse(
+data class PdlMatrikkeladresse(
     val matrikkelId: Long?,
     val bruksenhetsnummer: String?,
     val tilleggsnavn: String?,
@@ -92,6 +92,6 @@ data class Matrikkeladresse(
     val kommunenummer: String?
 )
 
-data class UkjentBosted(
+data class PdlUkjentBosted(
     val bostedskommune: String?
 )

--- a/src/main/kotlin/no/nav/syfo/client/pdl/PdlPersonResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/PdlPersonResponse.kt
@@ -40,9 +40,9 @@ data class PdlHentPerson(
 data class PdlPerson(
     val navn: List<PdlPersonNavn>,
     val adressebeskyttelse: List<Adressebeskyttelse>?,
-    val bostedsadresse: List<Bostedsadresse>?,
-    val kontaktadresse: List<Kontaktadresse>?,
-    val oppholdsadresse: List<Oppholdsadresse>?,
+    val bostedsadresse: List<PdlBostedsadresse>?,
+    val kontaktadresse: List<PdlKontaktadresse>?,
+    val oppholdsadresse: List<PdlOppholdsadresse>?,
     val doedsfall: List<PdlDoedsfall>?,
     val tilrettelagtKommunikasjon: List<PdlTilrettelagtKommunikasjon>,
     val sikkerhetstiltak: List<PdlSikkerhetstiltak>,
@@ -75,7 +75,7 @@ data class PdlPerson(
             }
         } ?: ""
 
-    fun hentBostedsadresse(): Bostedsadresse? =
+    fun hentPdlBostedsadresse(): PdlBostedsadresse? =
         bostedsadresse?.filter { it.gyldigFraOgMed != null }?.maxByOrNull { it.gyldigFraOgMed!! }
 
     fun hentTilrettelagtKommunikasjon(): TilrettelagtKommunikasjon? =
@@ -97,10 +97,10 @@ data class PdlPerson(
 
     val dodsdato: LocalDate? = doedsfall?.firstOrNull()?.doedsdato
 
-    fun hentKontaktadresse(): Kontaktadresse? =
+    fun hentPdlKontaktadresse(): PdlKontaktadresse? =
         kontaktadresse?.filter { it.gyldigFraOgMed != null }?.maxByOrNull { it.gyldigFraOgMed!! }
 
-    fun hentOppholdsadresse(): Oppholdsadresse? =
+    fun hentPdlOppholdsadresse(): PdlOppholdsadresse? =
         oppholdsadresse?.filter { it.gyldigFraOgMed != null }?.maxByOrNull { it.gyldigFraOgMed!! }
 }
 

--- a/src/main/kotlin/no/nav/syfo/person/api/domain/PersonAdresseResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/person/api/domain/PersonAdresseResponse.kt
@@ -1,5 +1,7 @@
 package no.nav.syfo.person.api.domain
 
+import no.nav.syfo.client.kodeverk.Postinformasjon
+import no.nav.syfo.client.kodeverk.getPoststedByPostnummer
 import no.nav.syfo.client.pdl.*
 
 data class PersonAdresseResponse(
@@ -8,3 +10,175 @@ data class PersonAdresseResponse(
     val kontaktadresse: Kontaktadresse?,
     val oppholdsadresse: Oppholdsadresse?,
 )
+
+data class Bostedsadresse(
+    val vegadresse: Vegadresse?,
+    val matrikkeladresse: Matrikkeladresse?,
+    val utenlandskAdresse: UtenlandskAdresse?,
+    val ukjentBosted: UkjentBosted?,
+) {
+    constructor(pdlBostedsadresse: PdlBostedsadresse, postinformasjonList: List<Postinformasjon>) : this(
+        vegadresse = pdlBostedsadresse.vegadresse?.let { Vegadresse(it, postinformasjonList) },
+        matrikkeladresse = pdlBostedsadresse.matrikkeladresse?.let { Matrikkeladresse(it, postinformasjonList) },
+        utenlandskAdresse = pdlBostedsadresse.utenlandskAdresse?.let { UtenlandskAdresse(it) },
+        ukjentBosted = pdlBostedsadresse.ukjentBosted?.let { UkjentBosted(it) },
+    )
+}
+
+data class Kontaktadresse(
+    val type: KontaktadresseType,
+    val postboksadresse: Postboksadresse?,
+    val vegadresse: Vegadresse?,
+    val postadresseIFrittFormat: PostadresseIFrittFormat?,
+    val utenlandskAdresse: UtenlandskAdresse?,
+    val utenlandskAdresseIFrittFormat: UtenlandskAdresseIFrittFormat?,
+) {
+    constructor(pdlKontaktadresse: PdlKontaktadresse, postinformasjonList: List<Postinformasjon>) : this(
+        type = KontaktadresseType.valueOf(pdlKontaktadresse.type.name),
+        postboksadresse = pdlKontaktadresse.postboksadresse?.let { Postboksadresse(it, postinformasjonList) },
+        vegadresse = pdlKontaktadresse.vegadresse?.let { Vegadresse(it, postinformasjonList) },
+        postadresseIFrittFormat = pdlKontaktadresse.postadresseIFrittFormat?.let {
+            PostadresseIFrittFormat(
+                it,
+                postinformasjonList
+            )
+        },
+        utenlandskAdresse = pdlKontaktadresse.utenlandskAdresse?.let { UtenlandskAdresse(it) },
+        utenlandskAdresseIFrittFormat = pdlKontaktadresse.utenlandskAdresseIFrittFormat?.let {
+            UtenlandskAdresseIFrittFormat(
+                it
+            )
+        },
+    )
+}
+
+enum class KontaktadresseType {
+    Innland, Utland
+}
+
+data class Oppholdsadresse(
+    val utenlandskAdresse: UtenlandskAdresse?,
+    val vegadresse: Vegadresse?,
+    val matrikkeladresse: Matrikkeladresse?,
+    val oppholdAnnetSted: String?,
+) {
+    constructor(pdlOppholdsadresse: PdlOppholdsadresse, postinformasjonList: List<Postinformasjon>) : this(
+        utenlandskAdresse = pdlOppholdsadresse.utenlandskAdresse?.let { UtenlandskAdresse(it) },
+        vegadresse = pdlOppholdsadresse.vegadresse?.let { Vegadresse(it, postinformasjonList) },
+        matrikkeladresse = pdlOppholdsadresse.matrikkeladresse?.let { Matrikkeladresse(it, postinformasjonList) },
+        oppholdAnnetSted = pdlOppholdsadresse.oppholdAnnetSted,
+    )
+}
+
+data class PostadresseIFrittFormat(
+    val adresselinje1: String?,
+    val adresselinje2: String?,
+    val adresselinje3: String?,
+    val postnummer: String?,
+    val poststed: String?,
+) {
+    constructor(
+        pdlPostadresseIFrittFormat: PdlPostadresseIFrittFormat,
+        postinformasjonList: List<Postinformasjon>,
+    ) : this(
+        adresselinje1 = pdlPostadresseIFrittFormat.adresselinje1,
+        adresselinje2 = pdlPostadresseIFrittFormat.adresselinje2,
+        adresselinje3 = pdlPostadresseIFrittFormat.adresselinje3,
+        postnummer = pdlPostadresseIFrittFormat.postnummer,
+        poststed = postinformasjonList.getPoststedByPostnummer(pdlPostadresseIFrittFormat.postnummer),
+    )
+}
+
+data class Postboksadresse(
+    val postbokseier: String?,
+    val postboks: String,
+    val postnummer: String?,
+    val poststed: String?,
+) {
+    constructor(pdlPostboksadresse: PdlPostboksadresse, postinformasjonList: List<Postinformasjon>) : this(
+        postbokseier = pdlPostboksadresse.postbokseier,
+        postboks = pdlPostboksadresse.postboks,
+        postnummer = pdlPostboksadresse.postnummer,
+        poststed = postinformasjonList.getPoststedByPostnummer(pdlPostboksadresse.postnummer),
+    )
+}
+
+data class UtenlandskAdresse(
+    val adressenavnNummer: String?,
+    val bygningEtasjeLeilighet: String?,
+    val postboksNummerNavn: String?,
+    val postkode: String?,
+    val bySted: String?,
+    val regionDistriktOmraade: String?,
+    val landkode: String,
+) {
+    constructor(pdlUtenlandskAdresse: PdlUtenlandskAdresse) : this(
+        adressenavnNummer = pdlUtenlandskAdresse.adressenavnNummer,
+        bygningEtasjeLeilighet = pdlUtenlandskAdresse.bygningEtasjeLeilighet,
+        postboksNummerNavn = pdlUtenlandskAdresse.postboksNummerNavn,
+        postkode = pdlUtenlandskAdresse.postkode,
+        bySted = pdlUtenlandskAdresse.bySted,
+        regionDistriktOmraade = pdlUtenlandskAdresse.regionDistriktOmraade,
+        landkode = pdlUtenlandskAdresse.landkode,
+    )
+}
+
+data class UtenlandskAdresseIFrittFormat(
+    val adresselinje1: String?,
+    val adresselinje2: String?,
+    val adresselinje3: String?,
+    val postkode: String?,
+    val byEllerStedsnavn: String?,
+    val landkode: String,
+) {
+    constructor(pdlUtenlandskAdresseIFrittFormat: PdlUtenlandskAdresseIFrittFormat) : this(
+        adresselinje1 = pdlUtenlandskAdresseIFrittFormat.adresselinje1,
+        adresselinje2 = pdlUtenlandskAdresseIFrittFormat.adresselinje2,
+        adresselinje3 = pdlUtenlandskAdresseIFrittFormat.adresselinje3,
+        postkode = pdlUtenlandskAdresseIFrittFormat.postkode,
+        byEllerStedsnavn = pdlUtenlandskAdresseIFrittFormat.byEllerStedsnavn,
+        landkode = pdlUtenlandskAdresseIFrittFormat.landkode,
+    )
+}
+
+data class Vegadresse(
+    val husnummer: String?,
+    val husbokstav: String?,
+    val adressenavn: String?,
+    val tilleggsnavn: String?,
+    val postnummer: String?,
+    val poststed: String?,
+) {
+    constructor(pdlVegadresse: PdlVegadresse, postinformasjonListe: List<Postinformasjon>) : this(
+        husnummer = pdlVegadresse.husnummer,
+        husbokstav = pdlVegadresse.husbokstav,
+        adressenavn = pdlVegadresse.adressenavn,
+        tilleggsnavn = pdlVegadresse.tilleggsnavn,
+        postnummer = pdlVegadresse.postnummer,
+        poststed = postinformasjonListe.getPoststedByPostnummer(pdlVegadresse.postnummer),
+    )
+}
+
+data class Matrikkeladresse(
+    val bruksenhetsnummer: String?,
+    val tilleggsnavn: String?,
+    val postnummer: String?,
+    val poststed: String?,
+    val kommunenummer: String?,
+) {
+    constructor(pdlMatrikkeladresse: PdlMatrikkeladresse, postinformasjonListe: List<Postinformasjon>) : this(
+        bruksenhetsnummer = pdlMatrikkeladresse.bruksenhetsnummer,
+        tilleggsnavn = pdlMatrikkeladresse.tilleggsnavn,
+        postnummer = pdlMatrikkeladresse.postnummer,
+        poststed = postinformasjonListe.getPoststedByPostnummer(pdlMatrikkeladresse.postnummer),
+        kommunenummer = pdlMatrikkeladresse.kommunenummer,
+    )
+}
+
+data class UkjentBosted(
+    val bostedskommune: String?,
+) {
+    constructor(pdlUkjentBosted: PdlUkjentBosted) : this(
+        bostedskommune = pdlUkjentBosted.bostedskommune,
+    )
+}

--- a/src/test/kotlin/no/nav/syfo/person/api/PersonAdresseApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/person/api/PersonAdresseApiSpek.kt
@@ -56,9 +56,9 @@ class PersonAdresseApiSpek : Spek({
                             val personAdresseResponse: PersonAdresseResponse =
                                 objectMapper.readValue(response.content!!)
                             personAdresseResponse.navn shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.hentPerson?.fullName
-                            personAdresseResponse.bostedsadresse shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.hentPerson?.hentBostedsadresse()
-                            personAdresseResponse.kontaktadresse shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.hentPerson?.hentKontaktadresse()
-                            personAdresseResponse.oppholdsadresse shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.hentPerson?.hentOppholdsadresse()
+                            personAdresseResponse.bostedsadresse shouldBeEqualTo generatePersonAdresseResponse().bostedsadresse
+                            personAdresseResponse.kontaktadresse shouldBeEqualTo generatePersonAdresseResponse().kontaktadresse
+                            personAdresseResponse.oppholdsadresse shouldBeEqualTo generatePersonAdresseResponse().oppholdsadresse
                         }
                     }
                 }

--- a/src/test/kotlin/no/nav/syfo/testhelper/PdlPersonResponseGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/PdlPersonResponseGenerator.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.testhelper
 
 import no.nav.syfo.client.pdl.*
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 fun generatePdlPersonNavn(): PdlPersonNavn {
     return PdlPersonNavn(
@@ -17,40 +18,54 @@ fun generateAdressebeskyttelse(): Adressebeskyttelse {
     )
 }
 
-fun generateBostedsadress(): Bostedsadresse {
-    return Bostedsadresse(
+fun generatePdlBostedsadress(): PdlBostedsadresse {
+    return PdlBostedsadresse(
         angittFlyttedato = null,
-        gyldigFraOgMed = null,
+        gyldigFraOgMed = LocalDateTime.now().minusDays(1),
         gyldigTilOgMed = null,
         coAdressenavn = null,
-        vegadresse = null,
+        vegadresse = generatePdlVegadresse(),
         matrikkeladresse = null,
         utenlandskAdresse = null,
         ukjentBosted = null
     )
 }
 
-fun generateKontaktadressee(): Kontaktadresse {
-    return Kontaktadresse(
-        gyldigFraOgMed = null,
+fun generatePdlVegadresse(): PdlVegadresse {
+    return PdlVegadresse(
+        matrikkelId = null,
+        husnummer = null,
+        husbokstav = null,
+        bruksenhetsnummer = null,
+        adressenavn = null,
+        kommunenummer = null,
+        bydelsnummer = null,
+        tilleggsnavn = null,
+        postnummer = "1001",
+    )
+}
+
+fun generatePdlKontaktadressee(): PdlKontaktadresse {
+    return PdlKontaktadresse(
+        gyldigFraOgMed = LocalDateTime.now().minusDays(1),
         gyldigTilOgMed = null,
-        type = KontaktadresseType.Innland,
+        type = PdlKontaktadresseType.Innland,
         coAdressenavn = null,
         postboksadresse = null,
-        vegadresse = null,
+        vegadresse = generatePdlVegadresse(),
         postadresseIFrittFormat = null,
         utenlandskAdresse = null,
         utenlandskAdresseIFrittFormat = null
     )
 }
 
-fun generateOppholdsadresse(): Oppholdsadresse {
-    return Oppholdsadresse(
-        gyldigFraOgMed = null,
+fun generatePdlOppholdsadresse(): PdlOppholdsadresse {
+    return PdlOppholdsadresse(
+        gyldigFraOgMed = LocalDateTime.now().minusDays(1),
         gyldigTilOgMed = null,
         coAdressenavn = null,
         utenlandskAdresse = null,
-        vegadresse = null,
+        vegadresse = generatePdlVegadresse(),
         matrikkeladresse = null,
         oppholdAnnetSted = null
     )
@@ -103,13 +118,13 @@ fun generatePdlHentPerson(
                 adressebeskyttelse ?: generateAdressebeskyttelse()
             ),
             bostedsadresse = listOf(
-                generateBostedsadress()
+                generatePdlBostedsadress()
             ),
             kontaktadresse = listOf(
-                generateKontaktadressee()
+                generatePdlKontaktadressee()
             ),
             oppholdsadresse = listOf(
-                generateOppholdsadresse()
+                generatePdlOppholdsadresse()
             ),
             doedsfall = if (doedsdato == null) emptyList() else {
                 listOf(PdlDoedsfall(doedsdato))

--- a/src/test/kotlin/no/nav/syfo/testhelper/PersonAdresseResponseGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/PersonAdresseResponseGenerator.kt
@@ -1,0 +1,52 @@
+package no.nav.syfo.testhelper
+
+import no.nav.syfo.person.api.domain.*
+
+fun generatePersonAdresseResponse(): PersonAdresseResponse {
+    return PersonAdresseResponse(
+        navn = "First Middle Last",
+        bostedsadresse = generateBostedsadresse(),
+        kontaktadresse = generateKontaktAdresse(),
+        oppholdsadresse = generateOppholdsadresse(),
+    )
+}
+
+fun generateBostedsadresse(): Bostedsadresse {
+    return Bostedsadresse(
+        vegadresse = generateVegadresse(),
+        matrikkeladresse = null,
+        utenlandskAdresse = null,
+        ukjentBosted = null,
+    )
+}
+
+fun generateKontaktAdresse(): Kontaktadresse {
+    return Kontaktadresse(
+        type = KontaktadresseType.Innland,
+        postboksadresse = null,
+        vegadresse = generateVegadresse(),
+        postadresseIFrittFormat = null,
+        utenlandskAdresse = null,
+        utenlandskAdresseIFrittFormat = null,
+    )
+}
+
+fun generateOppholdsadresse(): Oppholdsadresse {
+    return Oppholdsadresse(
+        utenlandskAdresse = null,
+        vegadresse = generateVegadresse(),
+        matrikkeladresse = null,
+        oppholdAnnetSted = null,
+    )
+}
+
+fun generateVegadresse(): Vegadresse {
+    return Vegadresse(
+        husnummer = null,
+        husbokstav = null,
+        adressenavn = null,
+        postnummer = "1001",
+        poststed = "OSLO",
+        tilleggsnavn = null,
+    )
+}


### PR DESCRIPTION
When this is added we can use poststed in frontend. Now we avoid sending PDL classes through our app and to frontend. Prefix address classes from PDL with "Pdl".
Create new classes without the unneeded fields from pdl and poststed added.
Only the types of address with postnummer gets poststed (foreign adresses, for instance, do not have poststed.