### PR TITLE
IS-2547: Improve fetching time for skjermetkode for persons

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClient.kt
@@ -61,7 +61,7 @@ class VeilederTilgangskontrollClient(
 
     suspend fun hasVeilederAccessToPersonList(
         callId: String,
-        personIdentNumberList: List<PersonIdentNumber>,
+        personidenter: List<PersonIdentNumber>,
         token: String,
     ): List<PersonIdentNumber> {
         val oboToken = azureAdClient.getOnBehalfOfToken(
@@ -70,7 +70,7 @@ class VeilederTilgangskontrollClient(
         )?.accessToken ?: throw RuntimeException("Failed to request access to Person: Failed to get OBO token")
 
         return try {
-            val requestBody = personIdentNumberList.map { it.value }
+            val requestBody = personidenter.map { it.value }
 
             val response: HttpResponse = httpClient.post(tilgangskontrollPersonListUrl) {
                 accept(ContentType.Application.Json)

--- a/src/main/kotlin/no/nav/syfo/person/skjermingskode/SkjermingskodeService.kt
+++ b/src/main/kotlin/no/nav/syfo/person/skjermingskode/SkjermingskodeService.kt
@@ -1,32 +1,58 @@
 package no.nav.syfo.person.skjermingskode
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import no.nav.syfo.client.pdl.PdlClient
 import no.nav.syfo.client.skjermedepersonerpip.SkjermedePersonerPipClient
 import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.person.api.domain.PersonInfo
 import no.nav.syfo.person.api.domain.Skjermingskode
 
 class SkjermingskodeService(
     private val skjermedePersonerPipClient: SkjermedePersonerPipClient,
     private val pdlClient: PdlClient,
 ) {
-    suspend fun hentBrukersSkjermingskode(
+    suspend fun hentSkjermingskodeForPersonidenter(
         callId: String,
-        personIdent: PersonIdentNumber,
+        personidenter: List<PersonIdentNumber>,
         token: String,
-    ): Skjermingskode? {
-        val hasAdressebeskyttelse = pdlClient.hasAdressebeskyttelse(callId = callId, personIdent = personIdent)
-
-        return hasAdressebeskyttelse?.let {
-            when {
-                hasAdressebeskyttelse -> Skjermingskode.DISKRESJONSMERKET
-                else -> if (
-                    skjermedePersonerPipClient.isSkjermet(
-                        callId = callId,
-                        personIdentNumber = personIdent,
-                        token = token,
-                    )
-                ) Skjermingskode.EGEN_ANSATT else Skjermingskode.INGEN
+    ) =
+        personidenter.map { personident ->
+            val skjermingskode = hentBrukersSkjermingskode(
+                callId = callId,
+                personident = personident,
+                token = token,
+            )
+            Pair(personident, skjermingskode)
+        }.mapNotNull { (personident, skjermingskode) ->
+            skjermingskode.await()?.let {
+                PersonInfo(
+                    fnr = personident.value,
+                    skjermingskode = it,
+                )
             }
         }
-    }
+
+    private suspend fun hentBrukersSkjermingskode(
+        callId: String,
+        personident: PersonIdentNumber,
+        token: String,
+    ): Deferred<Skjermingskode?> =
+        CoroutineScope(Dispatchers.IO).async {
+            val hasAdressebeskyttelse = pdlClient.hasAdressebeskyttelse(callId = callId, personIdent = personident)
+            hasAdressebeskyttelse?.let {
+                if (hasAdressebeskyttelse) {
+                    Skjermingskode.DISKRESJONSMERKET
+                } else {
+                    val isSkjermet = skjermedePersonerPipClient.isSkjermet(
+                        callId = callId,
+                        personIdentNumber = personident,
+                        token = token,
+                    )
+                    if (isSkjermet) Skjermingskode.EGEN_ANSATT else Skjermingskode.INGEN
+                }
+            }
+        }
 }


### PR DESCRIPTION
- Setter hentingen av skjermetkode til å foregå i parallell. Tror dette vil gjøre dette kallet mye raskere for når oversikten henter skjermingskode for en liste med personer

- [x] Test i dev

Ved feil vil man vise feilmeldingen i toppen av skjermbildet
![Screenshot 2024-10-18 at 09 14 13](https://github.com/user-attachments/assets/92c28d28-3014-44a0-86a9-f4e51daebd4e)

