### PR TITLE
IS-2547: Avoid unnecessary calls to get obo token

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
@@ -81,7 +81,6 @@ fun Application.apiModule(
         baseUrl = environment.istilgangskontrollUrl,
         clientId = environment.istilgangskontrollClientId,
     )
-
     val kodeverkClient = KodeverkClient(
         azureAdClient = azureAdClient,
         redisStore = redisStore,

--- a/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClient.kt
@@ -68,10 +68,8 @@ class VeilederTilgangskontrollClient(
             scopeClientId = clientId,
             token = token,
         )?.accessToken ?: throw RuntimeException("Failed to request access to Person: Failed to get OBO token")
-
         return try {
             val requestBody = personidenter.map { it.value }
-
             val response: HttpResponse = httpClient.post(tilgangskontrollPersonListUrl) {
                 accept(ContentType.Application.Json)
                 contentType(ContentType.Application.Json)

--- a/src/main/kotlin/no/nav/syfo/person/api/PersonAPI.kt
+++ b/src/main/kotlin/no/nav/syfo/person/api/PersonAPI.kt
@@ -105,7 +105,7 @@ fun Route.registrerPersonApi(
                 val isSkjermet = skjermedePersonerPipClient.isSkjermet(
                     callId = callId,
                     personIdentNumber = personIdentNumber,
-                    token = token
+                    oboToken = skjermedePersonerPipClient.getOnBehalfOfToken(token),
                 )
                 call.respond(isSkjermet)
             }


### PR DESCRIPTION
Fjerner at vi henter `oboToken` for pip klienten for hver person i listen om `obotoken` ikke er cachet.
Vil forhåpentligvis fikse [disse](https://nav-it.slack.com/archives/G01ABN2E885/p1729601317388179) feilene.