### PR TITLE
IS-2720: Refactor to mockengine and remove deprecated api call

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
 
     testImplementation("com.nimbusds:nimbus-jose-jwt:$nimbusJoseJwtVersion")
     testImplementation("io.ktor:ktor-server-test-host:$ktorVersion")
+    testImplementation("io.ktor:ktor-client-mock:$ktorVersion")
     testImplementation("io.mockk:mockk:$mockkVersion")
     testImplementation("org.amshove.kluent:kluent:$kluentVersion")
     testImplementation("org.spekframework.spek2:spek-dsl-jvm:$spekVersion") {

--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -9,6 +9,12 @@ import no.nav.syfo.application.ApplicationState
 import no.nav.syfo.application.Environment
 import no.nav.syfo.application.api.apiModule
 import no.nav.syfo.application.cache.RedisStore
+import no.nav.syfo.client.azuread.AzureAdClient
+import no.nav.syfo.client.kodeverk.KodeverkClient
+import no.nav.syfo.client.krr.KRRClient
+import no.nav.syfo.client.pdl.PdlClient
+import no.nav.syfo.client.skjermedepersonerpip.SkjermedePersonerPipClient
+import no.nav.syfo.client.veiledertilgang.VeilederTilgangskontrollClient
 import no.nav.syfo.client.wellknown.getWellKnown
 import org.slf4j.LoggerFactory
 import redis.clients.jedis.DefaultJedisClientConfig
@@ -35,6 +41,41 @@ fun main() {
                 .build()
         )
     )
+    val azureAdClient = AzureAdClient(
+        azureAppClientId = environment.azureAppClientId,
+        azureAppClientSecret = environment.azureAppClientSecret,
+        azureOpenidConfigTokenEndpoint = environment.azureOpenidConfigTokenEndpoint,
+        redisStore = cache,
+    )
+    val krrClient = KRRClient(
+        azureAdClient = azureAdClient,
+        redisStore = cache,
+        baseUrl = environment.krrUrl,
+        clientId = environment.krrClientId,
+    )
+    val pdlClient = PdlClient(
+        azureAdClient = azureAdClient,
+        redisStore = cache,
+        baseUrl = environment.pdlUrl,
+        clientId = environment.pdlClientId,
+    )
+    val skjermedePersonerPipClient = SkjermedePersonerPipClient(
+        azureAdClient = azureAdClient,
+        redisStore = cache,
+        baseUrl = environment.skjermedePersonerPipUrl,
+        clientId = environment.skjermedePersonerPipClientId,
+    )
+    val veilederTilgangskontrollClient = VeilederTilgangskontrollClient(
+        azureAdClient = azureAdClient,
+        baseUrl = environment.istilgangskontrollUrl,
+        clientId = environment.istilgangskontrollClientId,
+    )
+    val kodeverkClient = KodeverkClient(
+        azureAdClient = azureAdClient,
+        redisStore = cache,
+        baseUrl = environment.kodeverkUrl,
+        clientId = environment.kodeverkClientId,
+    )
 
     val server = embeddedServer(
         Netty,
@@ -55,7 +96,11 @@ fun main() {
                     applicationState = applicationState,
                     environment = environment,
                     wellKnownInternalAzureAD = wellKnownInternalAzureAD,
-                    redisStore = cache,
+                    krrClient = krrClient,
+                    pdlClient = pdlClient,
+                    skjermedePersonerPipClient = skjermedePersonerPipClient,
+                    kodeverkClient = kodeverkClient,
+                    veilederTilgangskontrollClient = veilederTilgangskontrollClient,
                 )
             }
         }

--- a/src/main/kotlin/no/nav/syfo/client/azuread/AzureAdClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/azuread/AzureAdClient.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.client.azuread
 
+import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.plugins.*
 import io.ktor.client.request.*
@@ -17,8 +18,8 @@ class AzureAdClient(
     private val azureAppClientSecret: String,
     private val azureOpenidConfigTokenEndpoint: String,
     private val redisStore: RedisStore,
+    private val httpClient: HttpClient = httpClientProxy(),
 ) {
-    private val httpClient = httpClientProxy()
 
     suspend fun getOnBehalfOfToken(
         scopeClientId: String,

--- a/src/main/kotlin/no/nav/syfo/client/kodeverk/KodeverkClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/kodeverk/KodeverkClient.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.client.kodeverk
 
+import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.plugins.*
 import io.ktor.client.request.*
@@ -19,8 +20,8 @@ class KodeverkClient(
     private val redisStore: RedisStore,
     private val baseUrl: String,
     private val clientId: String,
+    private val httpClient: HttpClient = httpClientDefault(),
 ) {
-    private val httpClient = httpClientDefault()
 
     suspend fun getPostinformasjon(
         callId: String,

--- a/src/main/kotlin/no/nav/syfo/client/krr/KRRClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/krr/KRRClient.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.client.krr
 
+import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.plugins.*
 import io.ktor.client.request.*
@@ -19,8 +20,8 @@ class KRRClient(
     private val redisStore: RedisStore,
     baseUrl: String,
     private val clientId: String,
+    private val httpClient: HttpClient = httpClientDefault(),
 ) {
-    private val httpClient = httpClientDefault()
 
     private val krrKontaktinfoUrl: String = "$baseUrl$KRR_KONTAKTINFORMASJON_BOLK_PATH"
 

--- a/src/main/kotlin/no/nav/syfo/client/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdl/PdlClient.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.client.pdl
 
+import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.plugins.*
 import io.ktor.client.request.*
@@ -19,8 +20,8 @@ class PdlClient(
     private val redisStore: RedisStore,
     private val baseUrl: String,
     private val clientId: String,
+    private val httpClient: HttpClient = httpClientDefault(),
 ) {
-    private val httpClient = httpClientDefault()
 
     suspend fun hasAdressebeskyttelse(
         callId: String,

--- a/src/main/kotlin/no/nav/syfo/client/skjermedepersonerpip/SkjermedePersonerRequestDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/client/skjermedepersonerpip/SkjermedePersonerRequestDTO.kt
@@ -1,0 +1,5 @@
+package no.nav.syfo.client.skjermedepersonerpip
+
+data class SkjermedePersonerRequestDTO(
+    val personident: String,
+)

--- a/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClient.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.client.veiledertilgang
 
+import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.plugins.*
 import io.ktor.client.request.*
@@ -17,8 +18,8 @@ class VeilederTilgangskontrollClient(
     private val azureAdClient: AzureAdClient,
     baseUrl: String,
     private val clientId: String,
+    private val httpClient: HttpClient = httpClientDefault(),
 ) {
-    private val httpClient = httpClientDefault()
 
     private val tilgangskontrollPersonUrl = "$baseUrl$TILGANGSKONTROLL_PERSON_PATH"
     private val tilgangskontrollPersonListUrl = "$baseUrl$TILGANGSKONTROLL_PERSON_LIST_PATH"

--- a/src/test/kotlin/no/nav/syfo/client/kodeverk/KodeverkClientSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/client/kodeverk/KodeverkClientSpek.kt
@@ -20,8 +20,9 @@ class KodeverkClientSpek : Spek({
     val kodeverkClient = KodeverkClient(
         azureAdClient = azureAdClient,
         redisStore = redisStore,
-        baseUrl = externalMockEnvironment.kodeverkMock.url,
+        baseUrl = externalMockEnvironment.environment.kodeverkUrl,
         clientId = externalMockEnvironment.environment.kodeverkClientId,
+        httpClient = externalMockEnvironment.mockHttpClient,
     )
 
     coEvery {

--- a/src/test/kotlin/no/nav/syfo/client/pdl/PdlClientSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/client/pdl/PdlClientSpek.kt
@@ -25,8 +25,9 @@ class PdlClientSpek : Spek({
     val pdlClient = PdlClient(
         azureAdClient = azureAdClient,
         redisStore = cacheMock,
-        baseUrl = externalMockEnvironment.pdlMock.url,
+        baseUrl = externalMockEnvironment.environment.pdlUrl,
         clientId = externalMockEnvironment.environment.pdlClientId,
+        httpClient = externalMockEnvironment.mockHttpClient,
     )
 
     coEvery {

--- a/src/test/kotlin/no/nav/syfo/person/api/PersonAdresseApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/person/api/PersonAdresseApiSpek.kt
@@ -55,7 +55,7 @@ class PersonAdresseApiSpek : Spek({
                             response.status() shouldBeEqualTo HttpStatusCode.OK
                             val personAdresseResponse: PersonAdresseResponse =
                                 objectMapper.readValue(response.content!!)
-                            personAdresseResponse.navn shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.hentPerson?.fullName
+                            personAdresseResponse.navn shouldBeEqualTo generatePdlPersonResponse().data?.hentPerson?.fullName
                             personAdresseResponse.bostedsadresse shouldBeEqualTo generatePersonAdresseResponse().bostedsadresse
                             personAdresseResponse.kontaktadresse shouldBeEqualTo generatePersonAdresseResponse().kontaktadresse
                             personAdresseResponse.oppholdsadresse shouldBeEqualTo generatePersonAdresseResponse().oppholdsadresse

--- a/src/test/kotlin/no/nav/syfo/person/api/PersonBrukerinfoApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/person/api/PersonBrukerinfoApiSpek.kt
@@ -71,7 +71,7 @@ class PersonBrukerinfoApiSpek : Spek({
                             syfomodiapersonBrukerinfo.kontaktinfo.epost shouldBeEqualTo digitalKontaktinfoBolkKanVarslesTrue.epostadresse
                             syfomodiapersonBrukerinfo.kontaktinfo.tlf shouldBeEqualTo digitalKontaktinfoBolkKanVarslesTrue.mobiltelefonnummer
                             syfomodiapersonBrukerinfo.kontaktinfo.skalHaVarsel shouldBeEqualTo true
-                            syfomodiapersonBrukerinfo.navn shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.hentPerson?.fullName
+                            syfomodiapersonBrukerinfo.navn shouldBeEqualTo generatePdlPersonResponse().data?.hentPerson?.fullName
                             syfomodiapersonBrukerinfo.dodsdato shouldBe null
                             syfomodiapersonBrukerinfo.tilrettelagtKommunikasjon shouldBe null
                         }
@@ -86,7 +86,7 @@ class PersonBrukerinfoApiSpek : Spek({
                             response.status() shouldBeEqualTo HttpStatusCode.OK
                             val syfomodiapersonBrukerinfo: SyfomodiapersonBrukerinfo =
                                 objectMapper.readValue(response.content!!)
-                            syfomodiapersonBrukerinfo.navn shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.hentPerson?.fullName
+                            syfomodiapersonBrukerinfo.navn shouldBeEqualTo generatePdlPersonResponse().data?.hentPerson?.fullName
                             syfomodiapersonBrukerinfo.dodsdato shouldBeEqualTo LocalDate.now()
                         }
                     }

--- a/src/test/kotlin/no/nav/syfo/person/api/PersonNavnApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/person/api/PersonNavnApiSpek.kt
@@ -55,7 +55,7 @@ class PersonNavnApiSpek : Spek({
                             response.status() shouldBeEqualTo HttpStatusCode.OK
                             val fnrMedNavn: FnrMedNavn = objectMapper.readValue(response.content!!)
                             fnrMedNavn.fnr shouldBeEqualTo ARBEIDSTAKER_PERSONIDENT.value
-                            fnrMedNavn.navn shouldBeEqualTo externalMockEnvironment.pdlMock.personResponseDefault.data?.hentPerson?.fullName
+                            fnrMedNavn.navn shouldBeEqualTo generatePdlPersonResponse().data?.hentPerson?.fullName
                         }
                     }
                 }

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestApiModule.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestApiModule.kt
@@ -2,33 +2,66 @@ package no.nav.syfo.testhelper
 
 import io.ktor.server.application.*
 import no.nav.syfo.application.api.apiModule
-import no.nav.syfo.application.cache.RedisStore
-import redis.clients.jedis.DefaultJedisClientConfig
-import redis.clients.jedis.HostAndPort
-import redis.clients.jedis.JedisPool
-import redis.clients.jedis.JedisPoolConfig
+import no.nav.syfo.client.azuread.AzureAdClient
+import no.nav.syfo.client.kodeverk.KodeverkClient
+import no.nav.syfo.client.krr.KRRClient
+import no.nav.syfo.client.pdl.PdlClient
+import no.nav.syfo.client.skjermedepersonerpip.SkjermedePersonerPipClient
+import no.nav.syfo.client.veiledertilgang.VeilederTilgangskontrollClient
 
 fun Application.testApiModule(
     externalMockEnvironment: ExternalMockEnvironment,
 ) {
-    val redisConfig = externalMockEnvironment.environment.redisConfig
-    val cache = RedisStore(
-        JedisPool(
-            JedisPoolConfig(),
-            HostAndPort(redisConfig.host, redisConfig.port),
-            DefaultJedisClientConfig.builder()
-                .ssl(redisConfig.ssl)
-                .password(redisConfig.redisPassword)
-                .build()
-        )
+    val azureAdClient = AzureAdClient(
+        azureAppClientId = externalMockEnvironment.environment.azureAppClientId,
+        azureAppClientSecret = externalMockEnvironment.environment.azureAppClientSecret,
+        azureOpenidConfigTokenEndpoint = externalMockEnvironment.environment.azureOpenidConfigTokenEndpoint,
+        redisStore = externalMockEnvironment.redisCache,
+        httpClient = externalMockEnvironment.mockHttpClient,
     )
-
-    externalMockEnvironment.redisCache = cache
+    val krrClient = KRRClient(
+        azureAdClient = azureAdClient,
+        redisStore = externalMockEnvironment.redisCache,
+        baseUrl = externalMockEnvironment.environment.krrUrl,
+        clientId = externalMockEnvironment.environment.krrClientId,
+        httpClient = externalMockEnvironment.mockHttpClient,
+    )
+    val pdlClient = PdlClient(
+        azureAdClient = azureAdClient,
+        redisStore = externalMockEnvironment.redisCache,
+        baseUrl = externalMockEnvironment.environment.pdlUrl,
+        clientId = externalMockEnvironment.environment.pdlClientId,
+        httpClient = externalMockEnvironment.mockHttpClient,
+    )
+    val skjermedePersonerPipClient = SkjermedePersonerPipClient(
+        azureAdClient = azureAdClient,
+        redisStore = externalMockEnvironment.redisCache,
+        baseUrl = externalMockEnvironment.environment.skjermedePersonerPipUrl,
+        clientId = externalMockEnvironment.environment.skjermedePersonerPipClientId,
+        httpClient = externalMockEnvironment.mockHttpClient,
+    )
+    val veilederTilgangskontrollClient = VeilederTilgangskontrollClient(
+        azureAdClient = azureAdClient,
+        baseUrl = externalMockEnvironment.environment.istilgangskontrollUrl,
+        clientId = externalMockEnvironment.environment.istilgangskontrollClientId,
+        httpClient = externalMockEnvironment.mockHttpClient,
+    )
+    val kodeverkClient = KodeverkClient(
+        azureAdClient = azureAdClient,
+        redisStore = externalMockEnvironment.redisCache,
+        baseUrl = externalMockEnvironment.environment.kodeverkUrl,
+        clientId = externalMockEnvironment.environment.kodeverkClientId,
+        httpClient = externalMockEnvironment.mockHttpClient,
+    )
 
     this.apiModule(
         applicationState = externalMockEnvironment.applicationState,
         environment = externalMockEnvironment.environment,
         wellKnownInternalAzureAD = externalMockEnvironment.wellKnownInternalAzureAD,
-        redisStore = externalMockEnvironment.redisCache,
+        krrClient = krrClient,
+        pdlClient = pdlClient,
+        skjermedePersonerPipClient = skjermedePersonerPipClient,
+        kodeverkClient = kodeverkClient,
+        veilederTilgangskontrollClient = veilederTilgangskontrollClient,
     )
 }

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
@@ -3,31 +3,23 @@ package no.nav.syfo.testhelper
 import no.nav.syfo.application.ApplicationState
 import no.nav.syfo.application.Environment
 import no.nav.syfo.application.cache.RedisConfig
-import java.net.ServerSocket
 import java.net.URI
 
-fun testEnvironment(
-    azureOpenIdTokenEndpoint: String = "azureTokenEndpoint",
-    krrUrl: String = "krr",
-    pdlUrl: String = "pdl",
-    skjermedePersonerPipUrl: String = "skjermedepersonerpip",
-    istilgangskontrollUrl: String = "tilgangskontroll",
-    kodeverkUrl: String = "kodeverk",
-) = Environment(
+fun testEnvironment() = Environment(
     azureAppClientId = "syfoperson-client-id",
     azureAppClientSecret = "syfoperson-secret",
     azureAppWellKnownUrl = "wellknown",
-    azureOpenidConfigTokenEndpoint = azureOpenIdTokenEndpoint,
+    azureOpenidConfigTokenEndpoint = "azureTokenEndpoint",
     krrClientId = "dev-gcp.team-rocket.digdir-krr-proxy",
-    krrUrl = krrUrl,
+    krrUrl = "krrUrl",
     pdlClientId = "dev-fss.pdl.pdl-api",
-    pdlUrl = pdlUrl,
+    pdlUrl = "pdlUrl",
     skjermedePersonerPipClientId = "dev-gcp.nom.skjermede-personer-pip",
-    skjermedePersonerPipUrl = skjermedePersonerPipUrl,
+    skjermedePersonerPipUrl = "skjermedePersonerPipUrl",
     istilgangskontrollClientId = "dev-gcp.teamsykefravr.istilgangskontroll",
-    istilgangskontrollUrl = istilgangskontrollUrl,
+    istilgangskontrollUrl = "istilgangskontrollUrl",
     kodeverkClientId = "dev-gcp.team-rocket.kodeverk-api",
-    kodeverkUrl = kodeverkUrl,
+    kodeverkUrl = "kodeverkUrl",
     redisConfig = RedisConfig(
         redisUri = URI("http://localhost:6379"),
         redisDB = 0,
@@ -41,7 +33,3 @@ fun testAppState() = ApplicationState(
     alive = true,
     ready = true,
 )
-
-fun getRandomPort() = ServerSocket(0).use {
-    it.localPort
-}

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/AzureADMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/AzureADMock.kt
@@ -1,14 +1,9 @@
 package no.nav.syfo.testhelper.mock
 
-import io.ktor.server.application.*
-import io.ktor.server.response.*
-import io.ktor.server.routing.*
-import io.ktor.server.engine.*
-import io.ktor.server.netty.*
-import no.nav.syfo.application.api.installContentNegotiation
+import io.ktor.client.engine.mock.*
+import io.ktor.client.request.*
 import no.nav.syfo.client.azuread.AzureAdTokenResponse
 import no.nav.syfo.client.wellknown.WellKnown
-import no.nav.syfo.testhelper.getRandomPort
 import java.nio.file.Paths
 
 fun wellKnownInternalAzureAD(): WellKnown {
@@ -20,26 +15,10 @@ fun wellKnownInternalAzureAD(): WellKnown {
     )
 }
 
-class AzureAdMock {
-    private val port = getRandomPort()
-    val url = "http://localhost:$port"
-
-    private val azureAdTokenResponse = AzureAdTokenResponse(
+fun MockRequestHandleScope.azureAdMockResponse(): HttpResponseData = respond(
+    AzureAdTokenResponse(
         access_token = "token",
         expires_in = 3600,
         token_type = "type",
     )
-
-    val name = "azuread"
-    val server = embeddedServer(
-        factory = Netty,
-        port = port,
-    ) {
-        installContentNegotiation()
-        routing {
-            post {
-                call.respond(azureAdTokenResponse)
-            }
-        }
-    }
-}
+)

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/KodeverkMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/KodeverkMock.kt
@@ -1,55 +1,33 @@
 package no.nav.syfo.testhelper.mock
 
+import io.ktor.client.engine.mock.*
+import io.ktor.client.request.*
 import io.ktor.http.*
-import io.ktor.server.application.*
-import io.ktor.server.engine.*
-import io.ktor.server.netty.*
-import io.ktor.server.response.*
-import io.ktor.server.routing.*
-import no.nav.syfo.application.api.installContentNegotiation
-import no.nav.syfo.client.kodeverk.*
-import no.nav.syfo.client.kodeverk.KodeverkClient.Companion.KODEVERK_POSTNUMMER_BETYDNINGER_PATH
-import no.nav.syfo.testhelper.getRandomPort
+import no.nav.syfo.client.kodeverk.Beskrivelse
+import no.nav.syfo.client.kodeverk.Betydning
+import no.nav.syfo.client.kodeverk.KodeverkBetydninger
 import no.nav.syfo.util.NAV_CALL_ID_HEADER
 
-class KodeverkMock {
-    private val port = getRandomPort()
-    val url = "http://localhost:$port"
-    val name = "kodeverk"
-
-    private val kodeverkResponse = KodeverkBetydninger(
-        betydninger = mapOf(
-            "1001" to listOf(
-                Betydning(
-                    gyldigFra = "1900-01-01",
-                    gyldigTil = "9999-12-31",
-                    beskrivelser = mapOf(
-                        "nb" to Beskrivelse(
-                            term = "OSLO",
-                            tekst = "OSLO",
-                        ),
+private val kodeverkResponse = KodeverkBetydninger(
+    betydninger = mapOf(
+        "1001" to listOf(
+            Betydning(
+                gyldigFra = "1900-01-01",
+                gyldigTil = "9999-12-31",
+                beskrivelser = mapOf(
+                    "nb" to Beskrivelse(
+                        term = "OSLO",
+                        tekst = "OSLO",
                     ),
                 ),
             ),
         ),
-    )
+    ),
+)
 
-    val server = embeddedServer(
-        factory = Netty,
-        port = port,
-    ) {
-        installContentNegotiation()
-        routing {
-            get(KODEVERK_POSTNUMMER_BETYDNINGER_PATH) {
-                when {
-                    call.request.headers[NAV_CALL_ID_HEADER] == "500" -> {
-                        call.respond(HttpStatusCode.InternalServerError)
-                    }
-                    else -> {
-                        call.respond(kodeverkResponse)
-                    }
-                }
-            }
-        }
+fun MockRequestHandleScope.kodeverkMockResponse(request: HttpRequestData): HttpResponseData {
+    return when (request.headers[NAV_CALL_ID_HEADER]) {
+        "500" -> respondError(HttpStatusCode.InternalServerError)
+        else -> respond(kodeverkResponse)
     }
 }

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/KrrMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/KrrMock.kt
@@ -1,15 +1,11 @@
 package no.nav.syfo.testhelper.mock
 
-import io.ktor.server.application.*
-import io.ktor.server.request.*
-import io.ktor.server.response.*
-import io.ktor.server.routing.*
-import io.ktor.server.engine.*
-import io.ktor.server.netty.*
-import no.nav.syfo.application.api.installContentNegotiation
-import no.nav.syfo.client.krr.*
+import io.ktor.client.engine.mock.*
+import io.ktor.client.request.*
+import no.nav.syfo.client.krr.DigitalKontaktinfo
+import no.nav.syfo.client.krr.DigitalKontaktinfoBolk
+import no.nav.syfo.client.krr.DigitalKontaktinfoBolkRequestBody
 import no.nav.syfo.testhelper.UserConstants
-import no.nav.syfo.testhelper.getRandomPort
 
 fun digitalKontaktinfoBolkKanVarslesTrue(personIdentNumber: String) = DigitalKontaktinfoBolk(
     personer = mapOf(
@@ -24,25 +20,11 @@ fun digitalKontaktinfoBolkKanVarslesTrue(personIdentNumber: String) = DigitalKon
     ),
 )
 
-class KrrMock {
-    private val port = getRandomPort()
-    val url = "http://localhost:$port"
-
-    val name = "krr"
-    val server = embeddedServer(
-        factory = Netty,
-        port = port,
-    ) {
-        installContentNegotiation()
-        routing {
-            post(KRRClient.KRR_KONTAKTINFORMASJON_BOLK_PATH) {
-                val krrRequestBody = call.receive<DigitalKontaktinfoBolkRequestBody>()
-                call.respond(
-                    digitalKontaktinfoBolkKanVarslesTrue(
-                        personIdentNumber = krrRequestBody.personidenter.first(),
-                    )
-                )
-            }
-        }
-    }
+suspend fun MockRequestHandleScope.krrMockResponse(request: HttpRequestData): HttpResponseData {
+    val krrRequestBody = request.receiveBody<DigitalKontaktinfoBolkRequestBody>()
+    return respond(
+        digitalKontaktinfoBolkKanVarslesTrue(
+            personIdentNumber = krrRequestBody.personidenter.first(),
+        )
+    )
 }

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/MockClient.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/MockClient.kt
@@ -1,0 +1,27 @@
+package no.nav.syfo.testhelper.mock
+
+import io.ktor.client.*
+import io.ktor.client.engine.mock.*
+import no.nav.syfo.application.Environment
+import no.nav.syfo.client.commonConfig
+
+fun getMockHttpClient(env: Environment) = HttpClient(MockEngine) {
+    commonConfig()
+    engine {
+        addHandler { request ->
+            val requestUrl = request.url.encodedPath
+            when {
+                requestUrl == "/${env.azureOpenidConfigTokenEndpoint}" -> azureAdMockResponse()
+                requestUrl.startsWith("/${env.istilgangskontrollUrl}") -> tilgangskontrollResponse(
+                    request
+                )
+                requestUrl.startsWith("/${env.skjermedePersonerPipUrl}") -> getSkjermedePersonerResponse(request)
+                requestUrl.startsWith("/${env.pdlUrl}") -> pdlMockResponse(request)
+                requestUrl.startsWith("/${env.krrUrl}") -> krrMockResponse(request)
+                requestUrl.startsWith("/${env.kodeverkUrl}") -> kodeverkMockResponse(request)
+
+                else -> error("Unhandled ${request.url.encodedPath}")
+            }
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/MockUtils.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/MockUtils.kt
@@ -1,0 +1,19 @@
+package no.nav.syfo.testhelper.mock
+
+import io.ktor.client.engine.mock.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import no.nav.syfo.util.configuredJacksonMapper
+
+val mapper = configuredJacksonMapper()
+
+suspend inline fun <reified T> HttpRequestData.receiveBody(): T {
+    return mapper.readValue(body.toByteArray(), T::class.java)
+}
+
+fun <T> MockRequestHandleScope.respond(body: T, statusCode: HttpStatusCode = HttpStatusCode.OK): HttpResponseData =
+    respond(
+        mapper.writeValueAsString(body),
+        statusCode,
+        headersOf(HttpHeaders.ContentType, "application/json")
+    )

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/PdlMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/PdlMock.kt
@@ -1,12 +1,7 @@
 package no.nav.syfo.testhelper.mock
 
-import io.ktor.server.application.*
-import io.ktor.server.request.*
-import io.ktor.server.response.*
-import io.ktor.server.routing.*
-import io.ktor.server.engine.*
-import io.ktor.server.netty.*
-import no.nav.syfo.application.api.installContentNegotiation
+import io.ktor.client.engine.mock.*
+import io.ktor.client.request.*
 import no.nav.syfo.client.pdl.*
 import no.nav.syfo.testhelper.*
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_ADRESSEBESKYTTET
@@ -16,36 +11,16 @@ import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_SIKKERHETSTILTAK
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_TILRETTELAGT_KOMMUNIKASJON
 import java.time.LocalDate
 
-class PdlMock {
-    private val port = getRandomPort()
-    val url = "http://localhost:$port"
-    val name = "pdl"
-    val personResponseDefault = generatePdlPersonResponse()
-
-    val server = embeddedServer(
-        factory = Netty,
-        port = port,
-    ) {
-        installContentNegotiation()
-        routing {
-            post {
-                val pdlRequest = call.receive<PdlRequest>()
-                call.respond(
-                    if (ARBEIDSTAKER_ADRESSEBESKYTTET.value == pdlRequest.variables.ident) {
-                        generatePdlPersonResponse(Gradering.STRENGT_FORTROLIG)
-                    } else if (ARBEIDSTAKER_DOD.value == pdlRequest.variables.ident) {
-                        generatePdlPersonResponse(doedsdato = LocalDate.now())
-                    } else if (ARBEIDSTAKER_TILRETTELAGT_KOMMUNIKASJON.value == pdlRequest.variables.ident) {
-                        generatePdlPersonResponse(tilrettelagtKommunikasjon = generatePdlTilrettelagtKommunikasjon())
-                    } else if (ARBEIDSTAKER_SIKKERHETSTILTAK.value == pdlRequest.variables.ident) {
-                        generatePdlPersonResponse(sikkerhetstiltak = generatePdlSikkerhetsiltak())
-                    } else if (ARBEIDSTAKER_PDL_ERROR.value == pdlRequest.variables.ident) {
-                        generatePdlPersonResponseError()
-                    } else {
-                        personResponseDefault
-                    }
-                )
-            }
-        }
+suspend fun MockRequestHandleScope.pdlMockResponse(request: HttpRequestData): HttpResponseData {
+    val pdlRequest = request.receiveBody<PdlRequest>()
+    return when (pdlRequest.variables.ident) {
+        ARBEIDSTAKER_ADRESSEBESKYTTET.value -> respond(generatePdlPersonResponse(Gradering.STRENGT_FORTROLIG))
+        ARBEIDSTAKER_DOD.value -> respond(generatePdlPersonResponse(doedsdato = LocalDate.now()))
+        ARBEIDSTAKER_TILRETTELAGT_KOMMUNIKASJON.value -> respond(
+            generatePdlPersonResponse(tilrettelagtKommunikasjon = generatePdlTilrettelagtKommunikasjon())
+        )
+        ARBEIDSTAKER_SIKKERHETSTILTAK.value -> respond(generatePdlPersonResponse(sikkerhetstiltak = generatePdlSikkerhetsiltak()))
+        ARBEIDSTAKER_PDL_ERROR.value -> respond(generatePdlPersonResponseError())
+        else -> respond(generatePdlPersonResponse())
     }
 }

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/SkjermedePersonerPipMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/SkjermedePersonerPipMock.kt
@@ -1,38 +1,20 @@
 package no.nav.syfo.testhelper.mock
 
-import io.ktor.server.application.*
-import io.ktor.server.response.*
-import io.ktor.server.routing.*
-import io.ktor.server.engine.*
-import io.ktor.server.netty.*
-import no.nav.syfo.application.api.installContentNegotiation
+import io.ktor.client.engine.mock.*
+import io.ktor.client.request.*
+import no.nav.syfo.client.skjermedepersonerpip.SkjermedePersonerRequestDTO
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_ADRESSEBESKYTTET
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_ALTERNATIVE_PERSONIDENT
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_PERSONIDENT
-import no.nav.syfo.testhelper.getRandomPort
 
-class SkjermedePersonerPipMock {
-    private val port = getRandomPort()
-    val url = "http://localhost:$port"
+suspend fun MockRequestHandleScope.getSkjermedePersonerResponse(request: HttpRequestData): HttpResponseData {
+    val skjermedePersonerRequestDTO = request.receiveBody<SkjermedePersonerRequestDTO>()
+    val personident = skjermedePersonerRequestDTO.personident
 
-    val name = "skjermedpersonerpip"
-    val server = embeddedServer(
-        factory = Netty,
-        port = port,
-    ) {
-        installContentNegotiation()
-        routing {
-            get("/skjermet") {
-                if (call.request.queryParameters["personident"] == ARBEIDSTAKER_PERSONIDENT.value) {
-                    call.respond(true)
-                }
-                if (call.request.queryParameters["personident"] == ARBEIDSTAKER_ALTERNATIVE_PERSONIDENT.value) {
-                    call.respond(false)
-                }
-                if (call.request.queryParameters["personident"] == ARBEIDSTAKER_ADRESSEBESKYTTET.value) {
-                    call.respond(false)
-                }
-            }
-        }
+    return when (personident) {
+        ARBEIDSTAKER_PERSONIDENT.value -> respond(true)
+        ARBEIDSTAKER_ALTERNATIVE_PERSONIDENT.value -> respond(false)
+        ARBEIDSTAKER_ADRESSEBESKYTTET.value -> respond(false)
+        else -> error("Unhandled personident")
     }
 }

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/VeilederTilgangskontrollMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/VeilederTilgangskontrollMock.kt
@@ -1,12 +1,7 @@
 package no.nav.syfo.testhelper.mock
 
-import io.ktor.server.application.*
-import io.ktor.http.*
-import io.ktor.server.response.*
-import io.ktor.server.routing.*
-import io.ktor.server.engine.*
-import io.ktor.server.netty.*
-import no.nav.syfo.application.api.installContentNegotiation
+import io.ktor.client.engine.mock.*
+import io.ktor.client.request.*
 import no.nav.syfo.client.veiledertilgang.Tilgang
 import no.nav.syfo.client.veiledertilgang.VeilederTilgangskontrollClient.Companion.TILGANGSKONTROLL_PERSON_LIST_PATH
 import no.nav.syfo.client.veiledertilgang.VeilederTilgangskontrollClient.Companion.TILGANGSKONTROLL_PERSON_PATH
@@ -15,49 +10,28 @@ import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_ADRESSEBESKYTTET
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_ALTERNATIVE_PERSONIDENT
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_PDL_ERROR
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_PERSONIDENT
-import no.nav.syfo.testhelper.getRandomPort
 import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
 
-class VeilederTilgangskontrollMock {
-    private val port = getRandomPort()
-    val url = "http://localhost:$port"
-    val tilgangFalse = Tilgang(
-        erGodkjent = false,
-    )
-    val tilgangTrue = Tilgang(
-        erGodkjent = true,
-    )
+fun MockRequestHandleScope.tilgangskontrollResponse(request: HttpRequestData): HttpResponseData {
+    val requestUrl = request.url.encodedPath
 
-    val name = "veiledertilgangskontroll"
-    val server = embeddedServer(
-        factory = Netty,
-        port = port,
-    ) {
-        installContentNegotiation()
-        routing {
-            get(TILGANGSKONTROLL_PERSON_PATH) {
-                when {
-                    call.request.headers[NAV_PERSONIDENT_HEADER] == UserConstants.ARBEIDSTAKER_VEILEDER_NO_ACCESS.value -> {
-                        call.respond(HttpStatusCode.Forbidden, tilgangFalse)
-                    }
-                    call.request.headers[NAV_PERSONIDENT_HEADER] != null -> {
-                        call.respond(tilgangTrue)
-                    }
-                    else -> {
-                        call.respond(HttpStatusCode.BadRequest)
-                    }
-                }
-            }
-            post(TILGANGSKONTROLL_PERSON_LIST_PATH) {
-                call.respond(
-                    listOf(
-                        ARBEIDSTAKER_PERSONIDENT.value,
-                        ARBEIDSTAKER_ALTERNATIVE_PERSONIDENT.value,
-                        ARBEIDSTAKER_ADRESSEBESKYTTET.value,
-                        ARBEIDSTAKER_PDL_ERROR.value,
-                    )
-                )
+    return when {
+        requestUrl.endsWith(TILGANGSKONTROLL_PERSON_PATH) -> {
+            when (request.headers[NAV_PERSONIDENT_HEADER]) {
+                UserConstants.ARBEIDSTAKER_VEILEDER_NO_ACCESS.value -> respond(Tilgang(erGodkjent = false))
+                else -> respond(Tilgang(erGodkjent = true))
             }
         }
+        requestUrl.endsWith(TILGANGSKONTROLL_PERSON_LIST_PATH) -> {
+            respond(
+                listOf(
+                    ARBEIDSTAKER_PERSONIDENT.value,
+                    ARBEIDSTAKER_ALTERNATIVE_PERSONIDENT.value,
+                    ARBEIDSTAKER_ADRESSEBESKYTTET.value,
+                    ARBEIDSTAKER_PDL_ERROR.value,
+                )
+            )
+        }
+        else -> error("Unhandled path $requestUrl")
     }
 }


### PR DESCRIPTION
Refaktorerer test-mocks til mockengine før migrering til ktor3. Oppdaget samtidig at APIet vi kaller hos skjermede-personer-pip sender fnr i urlen og er deprecated. Endrer til å bruke APIet som tar fnr i request-body i stedet.