### PR TITLE
IS-2897: Adjust kontaktinformasjon response dto

### DIFF
--- a/src/main/kotlin/no/nav/syfo/person/api/PersonAPI.kt
+++ b/src/main/kotlin/no/nav/syfo/person/api/PersonAPI.kt
@@ -179,7 +179,7 @@ fun Route.registrerPersonApi(
                     callId = callId,
                     personIdentNumber = personIdentNumber,
                     token = token,
-                )
+                ).toSyfomodiapersonKontaktinfo()
                 call.respond(response)
             }
         }

--- a/src/test/kotlin/no/nav/syfo/person/api/PersonKontaktinformasjonApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/person/api/PersonKontaktinformasjonApiSpek.kt
@@ -4,11 +4,10 @@ import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.server.testing.*
-import no.nav.syfo.client.krr.DigitalKontaktinfo
+import no.nav.syfo.person.api.domain.syfomodiaperson.SyfomodiapersonKontaktinfo
 import no.nav.syfo.testhelper.*
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_PERSONIDENT
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_VEILEDER_NO_ACCESS
-import no.nav.syfo.testhelper.mock.digitalKontaktinfoBolkKanVarslesTrue
 import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
 import org.amshove.kluent.shouldBeEqualTo
 import org.spekframework.spek2.Spek
@@ -45,11 +44,11 @@ class PersonKontaktinformasjonApiSpek : Spek({
                         }
 
                         response.status shouldBeEqualTo HttpStatusCode.OK
-                        val digitalKontaktinfo = response.body<DigitalKontaktinfo>()
-                        digitalKontaktinfo.personident shouldBeEqualTo ARBEIDSTAKER_PERSONIDENT.value
-                        digitalKontaktinfo shouldBeEqualTo digitalKontaktinfoBolkKanVarslesTrue(
-                            personIdentNumber = ARBEIDSTAKER_PERSONIDENT.value,
-                        ).personer?.get(ARBEIDSTAKER_PERSONIDENT.value)
+                        val digitalKontaktinfo = response.body<SyfomodiapersonKontaktinfo>()
+                        digitalKontaktinfo.fnr shouldBeEqualTo ARBEIDSTAKER_PERSONIDENT.value
+                        digitalKontaktinfo.skalHaVarsel shouldBeEqualTo true
+                        digitalKontaktinfo.tlf shouldBeEqualTo UserConstants.PERSON_TLF
+                        digitalKontaktinfo.epost shouldBeEqualTo UserConstants.PERSON_EMAIL
                     }
                 }
             }


### PR DESCRIPTION
Legger til rette for at `syfomodiaperson` kan bruke `/kontaktinformasjon`-endepunktet til å hente kontaktinfo fra KRR (ser ikke ut til at dette endepunktet er i [bruk](https://prometheus.prod-gcp.nav.cloud.nais.io/query?g0.expr=ktor_http_server_requests_seconds_count%7Bapp%3D%22syfoperson%22%7D&g0.show_tree=0&g0.tab=table&g0.range_input=1d&g0.res_type=auto&g0.res_density=medium&g0.display_mode=lines&g0.show_exemplars=0) i dag). I stedet for at det gjøres i kallet som henter navn (og andre data fra PDL). På den måte kan vi vise noe brukerinfo i `syfomodiaperson` selv om kall til KRR feiler.