### PR TITLE
IS-2897: Remove krr call from brukerinfo

### DIFF
--- a/src/main/kotlin/no/nav/syfo/person/api/PersonAPI.kt
+++ b/src/main/kotlin/no/nav/syfo/person/api/PersonAPI.kt
@@ -1,7 +1,6 @@
 package no.nav.syfo.person.api
 
 import io.ktor.http.*
-import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
@@ -194,15 +193,6 @@ fun Route.registrerPersonApi(
                 } ?: throw IllegalArgumentException("No personIdentNumber supplied in header")
 
                 val callId = getCallId()
-                val token = getBearerHeader()
-                    ?: throw IllegalArgumentException("No Authorization header supplied")
-
-                val kontaktinfo = krrClient.digitalKontaktinfo(
-                    callId = callId,
-                    personIdentNumber = personIdentNumber,
-                    token = token
-                ).toSyfomodiapersonKontaktinfo()
-
                 val pdlPerson = pdlClient.person(
                     callId = callId,
                     personIdentNumber = personIdentNumber,
@@ -211,7 +201,6 @@ fun Route.registrerPersonApi(
                 pdlPerson?.hentPerson?.let { person ->
                     val response = SyfomodiapersonBrukerinfo(
                         navn = person.fullName,
-                        kontaktinfo = kontaktinfo,
                         dodsdato = person.dodsdato,
                         tilrettelagtKommunikasjon = person.hentTilrettelagtKommunikasjon(),
                         sikkerhetstiltak = person.hentSikkerhetstiltak(),

--- a/src/main/kotlin/no/nav/syfo/person/api/domain/syfomodiaperson/SyfomodiapersonBrukerinfo.kt
+++ b/src/main/kotlin/no/nav/syfo/person/api/domain/syfomodiaperson/SyfomodiapersonBrukerinfo.kt
@@ -4,7 +4,6 @@ import java.time.LocalDate
 
 data class SyfomodiapersonBrukerinfo(
     val navn: String? = null,
-    val kontaktinfo: SyfomodiapersonKontaktinfo,
     val arbeidssituasjon: String = "ARBEIDSTAKER",
     val dodsdato: LocalDate? = null,
     val tilrettelagtKommunikasjon: TilrettelagtKommunikasjon? = null,

--- a/src/test/kotlin/no/nav/syfo/person/api/PersonBrukerinfoApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/person/api/PersonBrukerinfoApiSpek.kt
@@ -11,7 +11,6 @@ import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_PERSONIDENT
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_SIKKERHETSTILTAK
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_TILRETTELAGT_KOMMUNIKASJON
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_VEILEDER_NO_ACCESS
-import no.nav.syfo.testhelper.mock.digitalKontaktinfoBolkKanVarslesTrue
 import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
 import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldBeEqualTo
@@ -42,10 +41,6 @@ class PersonBrukerinfoApiSpek : Spek({
 
             describe("Happy path") {
                 it("should return OK if request is successful") {
-                    val digitalKontaktinfoBolkKanVarslesTrue = digitalKontaktinfoBolkKanVarslesTrue(
-                        personIdentNumber = ARBEIDSTAKER_PERSONIDENT.value,
-                    ).personer?.get(ARBEIDSTAKER_PERSONIDENT.value)!!
-
                     testApplication {
                         val client = setupApiAndClient(externalMockEnvironment)
                         val response = client.get(url) {
@@ -55,10 +50,6 @@ class PersonBrukerinfoApiSpek : Spek({
 
                         response.status shouldBeEqualTo HttpStatusCode.OK
                         val syfomodiapersonBrukerinfo = response.body<SyfomodiapersonBrukerinfo>()
-                        syfomodiapersonBrukerinfo.kontaktinfo.fnr shouldBeEqualTo ARBEIDSTAKER_PERSONIDENT.value
-                        syfomodiapersonBrukerinfo.kontaktinfo.epost shouldBeEqualTo digitalKontaktinfoBolkKanVarslesTrue.epostadresse
-                        syfomodiapersonBrukerinfo.kontaktinfo.tlf shouldBeEqualTo digitalKontaktinfoBolkKanVarslesTrue.mobiltelefonnummer
-                        syfomodiapersonBrukerinfo.kontaktinfo.skalHaVarsel shouldBeEqualTo true
                         syfomodiapersonBrukerinfo.navn shouldBeEqualTo generatePdlPersonResponse().data?.hentPerson?.fullName
                         syfomodiapersonBrukerinfo.dodsdato shouldBe null
                         syfomodiapersonBrukerinfo.tilrettelagtKommunikasjon shouldBe null


### PR DESCRIPTION
Nå bruker syfomodiaperson `/kontaktinformasjon`-endepunktet til å hente data fra krr.