### PR TITLE
IS-2700: Log warning if alder is null

### DIFF
--- a/src/main/kotlin/no/nav/syfo/person/api/PersonAPI.kt
+++ b/src/main/kotlin/no/nav/syfo/person/api/PersonAPI.kt
@@ -227,6 +227,9 @@ fun Route.registrerPersonApi(
                         tilrettelagtKommunikasjon = person.hentTilrettelagtKommunikasjon(),
                         sikkerhetstiltak = person.hentSikkerhetstiltak(),
                     )
+                    if (response.alder == null) {
+                        log.warn("Alder is null for person")
+                    }
                     call.respond(response)
                 } ?: call.respond(HttpStatusCode.InternalServerError)
             }


### PR DESCRIPTION
Legger på litt logging om `foedselsdato`-feltet vi henter fra PDL. Hvis dette mangler ofte burde vi kanskje generere alder fra fødselsnummer som en "backup". Men det kan være at det veldig sjelden mangler i prod selv om det forekommer ganske hyppig i testmiljøet.