### PR TITLE
IS-3348: Erstattet bruk av kotlin.test.asserts med JUnit

### DIFF
--- a/src/test/kotlin/no/nav/syfo/client/kodeverk/KodeverkClientTest.kt
+++ b/src/test/kotlin/no/nav/syfo/client/kodeverk/KodeverkClientTest.kt
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
-import kotlin.test.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 
 class KodeverkClientTest {
 

--- a/src/test/kotlin/no/nav/syfo/client/pdl/PdlClientTest.kt
+++ b/src/test/kotlin/no/nav/syfo/client/pdl/PdlClientTest.kt
@@ -14,9 +14,9 @@ import no.nav.syfo.testhelper.startExternalMocks
 import no.nav.syfo.testhelper.stopExternalMocks
 import org.junit.jupiter.api.*
 import java.time.LocalDateTime
-import kotlin.test.assertFalse
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 
 class PdlClientTest {
 

--- a/src/test/kotlin/no/nav/syfo/consumer/pdl/PdlPersonResponseTest.kt
+++ b/src/test/kotlin/no/nav/syfo/consumer/pdl/PdlPersonResponseTest.kt
@@ -6,9 +6,9 @@ import no.nav.syfo.client.pdl.PdlPersonNavn
 import no.nav.syfo.testhelper.UserConstants
 import no.nav.syfo.testhelper.generatePdlHentPerson
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import java.time.LocalDate
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
 
 class PdlPersonResponseTest {
 

--- a/src/test/kotlin/no/nav/syfo/person/api/PersonAdresseApiTest.kt
+++ b/src/test/kotlin/no/nav/syfo/person/api/PersonAdresseApiTest.kt
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 
 class PersonAdresseApiTest {
 

--- a/src/test/kotlin/no/nav/syfo/person/api/PersonBrukerinfoApiTest.kt
+++ b/src/test/kotlin/no/nav/syfo/person/api/PersonBrukerinfoApiTest.kt
@@ -19,10 +19,10 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import java.time.LocalDate
 
 class PersonBrukerinfoApiTest {

--- a/src/test/kotlin/no/nav/syfo/person/api/PersonDiskresjonskodeApiTest.kt
+++ b/src/test/kotlin/no/nav/syfo/person/api/PersonDiskresjonskodeApiTest.kt
@@ -8,7 +8,7 @@ import no.nav.syfo.testhelper.*
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_VEILEDER_NO_ACCESS
 import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
 import org.junit.jupiter.api.*
-import kotlin.test.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 
 class PersonDiskresjonskodeApiTest {
 

--- a/src/test/kotlin/no/nav/syfo/person/api/PersonEgenansattApiTest.kt
+++ b/src/test/kotlin/no/nav/syfo/person/api/PersonEgenansattApiTest.kt
@@ -9,8 +9,8 @@ import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_PERSONIDENT
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_VEILEDER_NO_ACCESS
 import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
 import org.junit.jupiter.api.*
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 
 class PersonEgenansattApiTest {
 

--- a/src/test/kotlin/no/nav/syfo/person/api/PersonInfoApiTest.kt
+++ b/src/test/kotlin/no/nav/syfo/person/api/PersonInfoApiTest.kt
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 
 class PersonInfoApiTest {
 

--- a/src/test/kotlin/no/nav/syfo/person/api/PersonKontaktinformasjonApiTest.kt
+++ b/src/test/kotlin/no/nav/syfo/person/api/PersonKontaktinformasjonApiTest.kt
@@ -14,8 +14,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 
 class PersonKontaktinformasjonApiTest {
 

--- a/src/test/kotlin/no/nav/syfo/person/api/PersonNavnApiTest.kt
+++ b/src/test/kotlin/no/nav/syfo/person/api/PersonNavnApiTest.kt
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 
 class PersonNavnApiTest {
 

--- a/src/test/kotlin/no/nav/syfo/util/StringUtilTest.kt
+++ b/src/test/kotlin/no/nav/syfo/util/StringUtilTest.kt
@@ -1,7 +1,7 @@
 package no.nav.syfo.util
 
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 
 class StringUtilTest {
 


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Ved overgang til JUnit i tidligere [PR](https://github.com/navikt/syfoperson/pull/233) så ble `kotlin.test.asserts` feilaktig lagt til i stedet for JUnit.
