### PR TITLE
IS-3791: Update Aareg DTO

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/aareg/AaregArbeidsforholdModels.kt
+++ b/src/main/kotlin/no/nav/syfo/client/aareg/AaregArbeidsforholdModels.kt
@@ -12,7 +12,6 @@ data class ArbeidsforholdRequest(
 
 // Sitat: "Dersom noen har flere yrker samtidig på samme underenhet vil de komme i 2 forskjellige arbeidsforhold. Det er fullt lovlig å bytte yrke underveis på samme arbeidsforhold"
 data class ArbeidsforholdResponse(
-    val id: String,
     val navArbeidsforholdId: Int,
     val opprettet: LocalDateTime,
     val sistBekreftet: LocalDateTime,

--- a/src/main/kotlin/no/nav/syfo/client/aareg/AaregClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/aareg/AaregClient.kt
@@ -23,6 +23,19 @@ class AaregClient(
 
     private val arbeidsforholdUrl: String = "$baseUrl$AAREG_ARBEIDSFORHOLD_PATH"
 
+    /**
+     * Henter arbeidsforhold for en person fra Aareg (Arbeidsgiver- og arbeidstakerregisteret).
+     * Resultatene caches i Valkey i 12 timer for å redusere antall kall til Aareg.
+     *
+     * Veileder trenger tilgang til AD-gruppen `0000-GA-Aa-register-Lese` for å kunne gjøre oppslaget.
+     *
+     * @param personident Fødselsnummeret til personen det gjøres oppslag på.
+     * @param token OBO-token for den innloggede veilederen, brukes til å hente et nytt OBO-token mot Aareg.
+     * @param callId Unik ID for den innkommende forespørselen, brukes for logging og sporing.
+     * @return Liste over [ArbeidsforholdResponse] for personen. Returnerer en tom liste dersom personen ikke ble funnet (404).
+     * @throws ResponseException Dersom Aareg returnerer 403 Forbidden eller en annen feilkode.
+     * @throws RuntimeException Dersom OBO-token ikke kan hentes.
+     */
     suspend fun getArbeidsforhold(
         personident: PersonIdentNumber,
         token: String,
@@ -60,19 +73,33 @@ class AaregClient(
                 )
                 response
             } catch (e: ResponseException) {
-                if (e.response.status == HttpStatusCode.NotFound) {
-                    emptyList()
-                } else {
-                    log.error(
-                        """
-                           Error while requesting response from Aareg:
-                           status: ${e.response.status.value}
-                           callId: $callId
-                           message: ${e.message}
-                        """.trimIndent()
-                    )
-                    COUNT_CALL_AAREG_ARBEIDSFORHOLD_FAIL.increment()
-                    throw e
+                when (e.response.status) {
+                    HttpStatusCode.NotFound -> {
+                        emptyList()
+                    }
+                    HttpStatusCode.Forbidden -> {
+                        log.warn(
+                            """
+                               Access denied while requesting response from Aareg:
+                               status: ${e.response.status.value}
+                               callId: $callId
+                               message: ${e.message}
+                            """.trimIndent()
+                        )
+                        throw e
+                    }
+                    else -> {
+                        log.error(
+                            """
+                               Error while requesting response from Aareg:
+                               status: ${e.response.status.value}
+                               callId: $callId
+                               message: ${e.message}
+                            """.trimIndent()
+                        )
+                        COUNT_CALL_AAREG_ARBEIDSFORHOLD_FAIL.increment()
+                        throw e
+                    }
                 }
             }
         }

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/AaregMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/AaregMock.kt
@@ -31,7 +31,6 @@ suspend fun MockRequestHandleScope.aaregMockResponse(request: HttpRequestData): 
 
 fun generateArbeidsforholdResponse(): ArbeidsforholdResponse =
     ArbeidsforholdResponse(
-        id = "123",
         navArbeidsforholdId = 1234567,
         opprettet = LocalDateTime.of(2020, 1, 1, 10, 0, 0),
         sistBekreftet = LocalDateTime.of(2024, 1, 1, 10, 0, 0),
@@ -70,7 +69,6 @@ fun generateArbeidsforholdResponse(): ArbeidsforholdResponse =
 
 private fun generateArbeidsforholdSeveralYrkerResponse(): ArbeidsforholdResponse =
     ArbeidsforholdResponse(
-        id = "123",
         navArbeidsforholdId = 1234567,
         opprettet = LocalDateTime.of(2020, 1, 1, 10, 0, 0),
         sistBekreftet = LocalDateTime.of(2024, 1, 1, 10, 0, 0),


### PR DESCRIPTION
- Vi får en del `null` på ID, og ifølge aareg-teamet er ikke denne alltid tilstede og burde ikke brukes som unik identifikator. Vi sendte den heller ikke videre så fjernet den.
- Vi fikk en del 403 som vi logget som feil, dette er pga manglende aareg-tilganger hos brukerne våre, og disse kan heller logges som warning.