### PR TITLE
fix NoSuchElementException in ArbeidsforholdPersonDTO

### DIFF
--- a/src/main/kotlin/no/nav/syfo/person/api/domain/AaregArbeidsforholdDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/person/api/domain/AaregArbeidsforholdDTO.kt
@@ -16,7 +16,11 @@ data class ArbeidsforholdPersonDTO(
         fun fromArbeidsforhold(personident: PersonIdentNumber, allArbeidsforholdResponse: List<ArbeidsforholdResponse>) =
             ArbeidsforholdPersonDTO(
                 personident = personident.value,
-                arbeidsforhold = allArbeidsforholdResponse.map { arbeidsforhold ->
+                arbeidsforhold = allArbeidsforholdResponse
+                    .filter { arbeidsforhold ->
+                        arbeidsforhold.arbeidssted.identer.any { it.type == IdentType.ORGANISASJONSNUMMER }
+                    }
+                    .map { arbeidsforhold ->
                     val gjeldendeAnsettelsesdetalj = arbeidsforhold.ansettelsesdetaljer.gjeldendeAnsettelsesdetalj()
                     ArbeidsforholdDTO(
                         navArbeidsforholdId = arbeidsforhold.navArbeidsforholdId,

--- a/src/main/kotlin/no/nav/syfo/person/api/domain/AaregArbeidsforholdDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/person/api/domain/AaregArbeidsforholdDTO.kt
@@ -13,20 +13,23 @@ data class ArbeidsforholdPersonDTO(
     val arbeidsforhold: List<ArbeidsforholdDTO>,
 ) {
     companion object {
-        fun fromArbeidsforhold(personident: PersonIdentNumber, allArbeidsforholdResponse: List<ArbeidsforholdResponse>) =
-            ArbeidsforholdPersonDTO(
-                personident = personident.value,
-                arbeidsforhold = allArbeidsforholdResponse
-                    .filter { arbeidsforhold ->
-                        arbeidsforhold.arbeidssted.identer.any { it.type == IdentType.ORGANISASJONSNUMMER }
-                    }
-                    .map { arbeidsforhold ->
+        fun fromArbeidsforhold(
+            personident: PersonIdentNumber,
+            allArbeidsforholdResponse: List<ArbeidsforholdResponse>,
+        ) = ArbeidsforholdPersonDTO(
+            personident = personident.value,
+            arbeidsforhold =
+            allArbeidsforholdResponse
+                .filter { arbeidsforhold ->
+                    arbeidsforhold.arbeidssted.identer.any { it.type == IdentType.ORGANISASJONSNUMMER }
+                }.map { arbeidsforhold ->
                     val gjeldendeAnsettelsesdetalj = arbeidsforhold.ansettelsesdetaljer.gjeldendeAnsettelsesdetalj()
                     ArbeidsforholdDTO(
                         navArbeidsforholdId = arbeidsforhold.navArbeidsforholdId,
                         opprettet = arbeidsforhold.opprettet,
                         sistBekreftet = arbeidsforhold.sistBekreftet,
-                        orgnummer = arbeidsforhold.arbeidssted.identer
+                        orgnummer =
+                        arbeidsforhold.arbeidssted.identer
                             .first { it.type == IdentType.ORGANISASJONSNUMMER }
                             .ident,
                         type = arbeidsforhold.type.beskrivelse,
@@ -34,10 +37,10 @@ data class ArbeidsforholdPersonDTO(
                         ansettelseSlutt = arbeidsforhold.ansettelsesperiode.sluttdato,
                         ansettelsesform = gjeldendeAnsettelsesdetalj.ansettelsesform?.beskrivelse,
                         yrke = gjeldendeAnsettelsesdetalj.yrke.beskrivelse,
-                        stillingsprosent = gjeldendeAnsettelsesdetalj.avtaltStillingsprosent.toInt().toString()
+                        stillingsprosent = gjeldendeAnsettelsesdetalj.avtaltStillingsprosent.toInt().toString(),
                     )
-                }
-            )
+                },
+        )
     }
 }
 

--- a/src/test/kotlin/no/nav/syfo/person/api/PersonArbeidsforholdApiTest.kt
+++ b/src/test/kotlin/no/nav/syfo/person/api/PersonArbeidsforholdApiTest.kt
@@ -10,6 +10,7 @@ import no.nav.syfo.client.aareg.ArbeidsforholdResponse
 import no.nav.syfo.client.azuread.AzureAdToken
 import no.nav.syfo.person.api.domain.ArbeidsforholdPersonDTO
 import no.nav.syfo.testhelper.ExternalMockEnvironment
+import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_AAREG_PERSON_ARBEIDSSTED
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_AAREG_SEVERAL_ARBEIDSFORHOLD
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_ALTERNATIVE_PERSONIDENT
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_PERSONIDENT
@@ -110,6 +111,25 @@ class PersonArbeidsforholdApiTest {
                 assertEquals(2, arbeidsforhold.size)
                 assertEquals("912345678", arbeidsforhold.first().orgnummer)
                 assertEquals("912345699", arbeidsforhold.last().orgnummer)
+            }
+        }
+
+        @Test
+        fun `should filter out arbeidsforhold with Person-type arbeidssted`() {
+            testApplication {
+                val client = setupApiAndClient(externalMockEnvironment)
+                val response = client.get(url) {
+                    bearerAuth(validToken)
+                    header(NAV_PERSONIDENT_HEADER, ARBEIDSTAKER_AAREG_PERSON_ARBEIDSSTED.value)
+                }
+
+                assertEquals(HttpStatusCode.OK, response.status)
+                val arbeidsforholdPerson = response.body<ArbeidsforholdPersonDTO>()
+                val arbeidsforhold = arbeidsforholdPerson.arbeidsforhold
+
+                assertEquals(ARBEIDSTAKER_AAREG_PERSON_ARBEIDSSTED.value, arbeidsforholdPerson.personident)
+                assertEquals(1, arbeidsforhold.size)
+                assertEquals("912345678", arbeidsforhold.first().orgnummer)
             }
         }
     }

--- a/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
@@ -9,6 +9,7 @@ object UserConstants {
 
     val ARBEIDSTAKER_AAREG_NOT_FOUND = PersonIdentNumber(ARBEIDSTAKER_PERSONIDENT.value.replace("2", "3"))
     val ARBEIDSTAKER_AAREG_SEVERAL_ARBEIDSFORHOLD = PersonIdentNumber(ARBEIDSTAKER_PERSONIDENT.value.replace("2", "0"))
+    val ARBEIDSTAKER_AAREG_PERSON_ARBEIDSSTED = PersonIdentNumber(ARBEIDSTAKER_PERSONIDENT.value.replace("2", "4"))
     val ARBEIDSTAKER_VEILEDER_NO_ACCESS = PersonIdentNumber(ARBEIDSTAKER_PERSONIDENT.value.replace("2", "1"))
     val ARBEIDSTAKER_ADRESSEBESKYTTET = PersonIdentNumber(ARBEIDSTAKER_PERSONIDENT.value.replace("2", "6"))
     val ARBEIDSTAKER_DOD = PersonIdentNumber(ARBEIDSTAKER_PERSONIDENT.value.replace("2", "7"))

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/AaregMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/AaregMock.kt
@@ -5,6 +5,7 @@ import io.ktor.client.request.*
 import io.ktor.http.*
 import no.nav.syfo.client.aareg.*
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_AAREG_NOT_FOUND
+import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_AAREG_PERSON_ARBEIDSSTED
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_AAREG_SEVERAL_ARBEIDSFORHOLD
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_ALTERNATIVE_PERSONIDENT
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_PERSONIDENT
@@ -22,6 +23,12 @@ suspend fun MockRequestHandleScope.aaregMockResponse(request: HttpRequestData): 
             listOf(
                 generateArbeidsforholdResponse(),
                 generateArbeidsforholdSeveralYrkerResponse(),
+            )
+        )
+        ARBEIDSTAKER_AAREG_PERSON_ARBEIDSSTED.value -> respond(
+            listOf(
+                generateArbeidsforholdResponse(),
+                generateArbeidsforholdPersonArbeidsstedResponse(),
             )
         )
         ARBEIDSTAKER_AAREG_NOT_FOUND.value -> respondError(HttpStatusCode.NotFound)
@@ -115,6 +122,44 @@ private fun generateArbeidsforholdSeveralYrkerResponse(): ArbeidsforholdResponse
                 avtaltStillingsprosent = 100.0,
                 rapporteringsmaaneder = FraTil(
                     fra = YearMonth.of(2020, 1),
+                    til = null,
+                )
+            ),
+        ),
+    )
+
+fun generateArbeidsforholdPersonArbeidsstedResponse(): ArbeidsforholdResponse =
+    ArbeidsforholdResponse(
+        navArbeidsforholdId = 9999999,
+        opprettet = LocalDateTime.of(2021, 1, 1, 10, 0, 0),
+        sistBekreftet = LocalDateTime.of(2024, 1, 1, 10, 0, 0),
+        type = Kode(
+            kode = "ordinaertArbeidsforhold",
+            beskrivelse = "Ordinært arbeidsforhold",
+        ),
+        arbeidssted = Arbeidssted(
+            type = ArbeidsstedType.Person,
+            identer = listOf(
+                Ident(type = IdentType.FOLKEREGISTERIDENT, ident = "99999999999")
+            )
+        ),
+        ansettelsesperiode = Ansettelsesperiode(
+            startdato = LocalDate.of(2021, 1, 1),
+        ),
+        ansettelsesdetaljer = listOf(
+            Ansettelsesdetalj(
+                ansettelsesform = Kode(
+                    kode = "fast",
+                    beskrivelse = "Fast ansettelse",
+                ),
+                yrke = Kode(
+                    kode = "5000",
+                    beskrivelse = "Hjemmearbeid",
+                ),
+                antallTimerPrUke = 37.5,
+                avtaltStillingsprosent = 100.0,
+                rapporteringsmaaneder = FraTil(
+                    fra = YearMonth.of(2021, 1),
                     til = null,
                 )
             ),


### PR DESCRIPTION
Ser det er noen innslag av disse i loggen våre nå
```
java.util.NoSuchElementException: Collection contains no element matching the predicate.
	at no.nav.syfo.person.api.domain.ArbeidsforholdPersonDTO$Companion.fromArbeidsforhold(AaregArbeidsforholdDTO.kt:57)
	at no.nav.syfo.person.api.PersonAPIKt$registrerPersonApi$1$7$1.invokeSuspend(PersonAPI.kt:211)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
	at io.opentelemetry.javaagent.instrumentation.kotlinxcoroutines.v1_0.RunnableWrapper.lambda$stopPropagation$0(RunnableWrapper.java:16)
	at io.opentelemetry.javaagent.bootstrap.executors.ContextPropagatingRunnable.run(ContextPropagatingRunnable.java:37)
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:148)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:141)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:535)
	at io.netty.channel.SingleThreadIoEventLoop.run(SingleThreadIoEventLoop.java:201)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:1195)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Unknown Source)
```